### PR TITLE
Minor README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ and you can use any gtp-compliant program with it.
 ```
 # Latest model should look like: /path/to/models/000123-something
 LATEST_MODEL=$(ls -d $MINIGO_MODELS/* | tail -1 | cut -f 1 -d '.')
-python3 main.py gtp $LATEST_MODEL -r $READOUTS -v 3
+BOARD_SIZE=19 python3 main.py gtp -l $LATEST_MODEL -r $READOUTS -v 3
 ```
 
 (If no model is provided, it will initialize one with random values)
@@ -207,13 +207,13 @@ speaks GTP.) You can download the gogui set of tools at
 GTP](http://gogui.sourceforge.net/doc/reference-twogtp.html).
 
 ```shell
-gogui-twogtp -black 'python3 main.py gtp gs://$BUCKET_NAME/models/000000-bootstrap' -white 'gogui-display' -size 19 -komi 7.5 -verbose -auto
+gogui-twogtp -black 'python3 main.py gtp -l gs://$BUCKET_NAME/models/000000-bootstrap' -white 'gogui-display' -size 19 -komi 7.5 -verbose -auto
 ```
 
 Another way to play via GTP is to watch it play against GnuGo, while spectating the games
 ```
 BLACK="gnugo --mode gtp"
-WHITE="python3 main.py gtp path/to/model"
+WHITE="python3 main.py gtp -l path/to/model"
 TWOGTP="gogui-twogtp -black \"$BLACK\" -white \"$WHITE\" -games 10 \
   -size 19 -alternate -sgffile gnugo"
 gogui -size 19 -program "$TWOGTP" -computer-both -auto


### PR DESCRIPTION
Add -l for model argument for main.py examples.
Also add BOARD_SIZE=19.

Looks like the other main.py commands take the model as a positional argument so maybe that's what the real fix should be.
