### PR TITLE
Clean up the cluster scripts

### DIFF
--- a/cluster/cluster-down
+++ b/cluster/cluster-down
@@ -2,4 +2,4 @@
 
 source ./common.sh
 
-gcloud container clusters delete $CLUSTER_NAME
+gcloud container clusters delete $CLUSTER_NAME --project=$PROJECT --zone=$ZONE

--- a/cluster/cluster-up
+++ b/cluster/cluster-up
@@ -13,6 +13,9 @@ echo "Using K8S Version:  ${K8S_VERSION}"
 gcloud beta container clusters create \
   --num-nodes 4 \
   --machine-type n1-standard-8 \
+  # Intel Broadwells are a bit newer, and can provide up to a 30% speedup,
+  # since we're so CPU bound.
+  --min-cpu-platform "Intel Broadwell" \
   --disk-size 30 \
   --zone $ZONE \
   --project $PROJECT \

--- a/cluster/cluster-up-gpu
+++ b/cluster/cluster-up-gpu
@@ -11,7 +11,7 @@ echo "Using K8S Version:  ${K8S_VERSION}"
 
 # Create a Kubernetes cluster. This setup is designed for creating large clusters.
 gcloud beta container clusters create \
-  --num-nodes 5 \
+  --num-nodes 600 \
   --accelerator type=nvidia-tesla-k80,count=1 \
   --machine-type n1-standard-2 \
   --disk-size 20 \

--- a/cluster/cluster-up-gpu
+++ b/cluster/cluster-up-gpu
@@ -4,20 +4,26 @@ source ./common.sh
 
 set -e
 
+echo "Using Project:      ${PROJECT}"
+echo "Using Zone:         ${ZONE}"
+echo "Using Cluster Name: ${CLUSTER_NAME}"
+echo "Using K8S Version:  ${K8S_VERSION}"
+
 # Create a Kubernetes cluster
-gcloud alpha container clusters create \
-  --enable-kubernetes-alpha \
+gcloud beta container clusters create \
   --num-nodes 5 \
   --accelerator type=nvidia-tesla-k80,count=1 \
   --machine-type n1-standard-2 \
   --disk-size 20 \
   --preemptible \
-  --cluster-ipv4-cidr=10.0.0.0/10 \
-  --zone=asia-east1-a \
+  --cluster-ipv4-cidr=10.0.0.0/10 \ # Allocate a big CIDR block for a big cluster
+  --zone=$ZONE \
+  --cluster-version=$K8S_VERSION \
+  --project=$PROJECT \
   $CLUSTER_NAME
 
 # Fetch its credentials so we can use kubectl locally
-gcloud container clusters get-credentials $CLUSTER_NAME
+gcloud container clusters get-credentials $CLUSTER_NAME --project $PROJECT --zone $ZONE
 
 # Import the credentials into the cluster as a secret
 kubectl create secret generic ${SERVICE_ACCOUNT}-creds --from-file=service-account.json=${SERVICE_ACCOUNT}-key.json

--- a/cluster/cluster-up-gpu
+++ b/cluster/cluster-up-gpu
@@ -9,14 +9,16 @@ echo "Using Zone:         ${ZONE}"
 echo "Using Cluster Name: ${CLUSTER_NAME}"
 echo "Using K8S Version:  ${K8S_VERSION}"
 
-# Create a Kubernetes cluster
+# Create a Kubernetes cluster. This setup is designed for creating large clusters.
 gcloud beta container clusters create \
   --num-nodes 5 \
   --accelerator type=nvidia-tesla-k80,count=1 \
   --machine-type n1-standard-2 \
   --disk-size 20 \
   --preemptible \
-  --cluster-ipv4-cidr=10.0.0.0/10 \ # Allocate a big CIDR block for a big cluster
+  # Allocating a big CIDR is necessary for large clusters (>1008 Nodes)
+  # See more details https://stackoverflow.com/questions/42129327/gke-cluster-creation-fails-because-the-network-default-does-not-have-available
+  --cluster-ipv4-cidr=10.0.0.0/10 \
   --zone=$ZONE \
   --cluster-version=$K8S_VERSION \
   --project=$PROJECT \

--- a/cluster/cluster-up-gpu-small
+++ b/cluster/cluster-up-gpu-small
@@ -9,13 +9,11 @@ echo "Using Zone:         ${ZONE}"
 echo "Using Cluster Name: ${CLUSTER_NAME}"
 echo "Using K8S Version:  ${K8S_VERSION}"
 
-# Create a Kubernetes cluster
+# Create a small Kubernetes gpu cluster.
 gcloud beta container clusters create \
   --num-nodes 5 \
   --accelerator type=nvidia-tesla-k80,count=1 \
   --machine-type n1-standard-2 \
-  --disk-size 20 \
-  --preemptible \
   --zone=$ZONE \
   --cluster-version=$K8S_VERSION \
   --project=$PROJECT \

--- a/cluster/cluster-up-gpu-small
+++ b/cluster/cluster-up-gpu-small
@@ -2,7 +2,7 @@
 
 source ./common.sh
 
-set -ex
+set -e
 
 echo "Using Project:      ${PROJECT}"
 echo "Using Zone:         ${ZONE}"
@@ -11,15 +11,18 @@ echo "Using K8S Version:  ${K8S_VERSION}"
 
 # Create a Kubernetes cluster
 gcloud beta container clusters create \
-  --num-nodes 4 \
-  --machine-type n1-standard-8 \
-  --disk-size 30 \
-  --zone $ZONE \
-  --project $PROJECT \
+  --num-nodes 5 \
+  --accelerator type=nvidia-tesla-k80,count=1 \
+  --machine-type n1-standard-2 \
+  --disk-size 20 \
+  --preemptible \
+  --zone=$ZONE \
+  --cluster-version=$K8S_VERSION \
+  --project=$PROJECT \
   $CLUSTER_NAME
 
 # Fetch its credentials so we can use kubectl locally
-gcloud container clusters get-credentials $CLUSTER_NAME --project $PROJECT --zone $ZONE
+gcloud container clusters get-credentials $CLUSTER_NAME --project=$PROJECT --zone=$ZONE
 
 # Import the credentials into the cluster as a secret
 kubectl create secret generic ${SERVICE_ACCOUNT}-creds --from-file=service-account.json=${SERVICE_ACCOUNT}-key.json

--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -5,4 +5,5 @@ export BUCKET_NAME=${BUCKET_NAME:-minigo-v2}
 export SERVICE_ACCOUNT=${SERVICE_ACCOUNT:-minigo-services2}
 export SERVICE_ACCOUNT_EMAIL=${SERVICE_ACCOUNT}@${PROJECT}.iam.gserviceaccount.com
 export BOARD_SIZE=${BOARD_SIZE:-19}
-
+export K8S_VERSION=${K8S_VERSION:-1.9.2-gke.0}
+export ZONE=${ZONE:-asia-east1-a}

--- a/cluster/deploy
+++ b/cluster/deploy
@@ -4,6 +4,7 @@ set -ex
 
 source ./common.sh
 
+
 # Create a GCS bucket for data storage
 gsutil mb -p $PROJECT gs://$BUCKET_NAME
 

--- a/cluster/deploy-gpu-player.sh
+++ b/cluster/deploy-gpu-player.sh
@@ -16,4 +16,6 @@
 
 source ./common.sh
 
+# TODO(kashomon): envsubst doesn't exist for OSX. needs to be brew-installed
+# via gettext. Should probably warn the user about that.
 envsubst < gpu-player.yaml | kubectl apply -f -

--- a/cluster/deploy-gpu-player.sh
+++ b/cluster/deploy-gpu-player.sh
@@ -16,6 +16,15 @@
 
 source ./common.sh
 
-# TODO(kashomon): envsubst doesn't exist for OSX. needs to be brew-installed
-# via gettext. Should probably warn the user about that.
+command -v envsubst >/dev/null 2>&1 || {
+  echo >&2 "envsubst is required and not found. Aborting"
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    echo >&2 "------------------------------------------------"
+    echo >&2 "If you're on OSX, you can install with brew via:"
+    echo >&2 "  brew install gettext"
+    echo >&2 "  brew link --force gettext"
+  fi
+  exit 1;
+}
+
 envsubst < gpu-player.yaml | kubectl apply -f -

--- a/cluster/destroy
+++ b/cluster/destroy
@@ -4,6 +4,8 @@ source ./common.sh
 
 ./cluster-down
 
-gcloud iam service-accounts delete $SERVICE_ACCOUNT_EMAIL
+# Left here for documentation, if you really wish to delete more things:
+#
+# gcloud iam service-accounts delete $SERVICE_ACCOUNT_EMAIL
 
-gsutil -m rm -r gs://$BUCKET_NAME
+# gsutil -m rm -r gs://$BUCKET_NAME


### PR DESCRIPTION
- Add a K8S Version option (and use 1.9.2)
- Switch to Beta track with 1.9.2 EAP
- Add a Zone option
- Explicitly set PROJECT/ZONE
- Make the destroy script less scary
- Make a cluster-up-gpu-small for test-size clusters