### PR TITLE
Small changes to dockerfiles

### DIFF
--- a/cluster/Dockerfile
+++ b/cluster/Dockerfile
@@ -35,4 +35,4 @@ RUN pip3 install -r /app/requirements-cpu.txt
 
 ADD staging/ /app
 
-ENTRYPOINT ["/bin/sh", "player_wrapper.sh"]
+CMD ["/bin/sh", "player_wrapper.sh"]

--- a/cluster/Dockerfile.gpu
+++ b/cluster/Dockerfile.gpu
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04
+FROM nvidia/cuda:9.0-cudnn7-runtime-ubuntu16.04
 
 RUN apt update && apt-get install -y --no-install-recommends \
         build-essential \
@@ -24,6 +24,7 @@ RUN apt update && apt-get install -y --no-install-recommends \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+
 WORKDIR /app
 
 ADD staging/requirements-gpu.txt /app/requirements-gpu.txt
@@ -33,4 +34,4 @@ RUN pip3 install -r /app/requirements-gpu.txt
 
 ADD staging/ /app
 
-ENTRYPOINT ["/bin/sh", "player_wrapper.sh"]
+CMD ["/bin/sh", "player_wrapper.sh"]


### PR DESCRIPTION
- Use the CUDA runtime rather than devel (I don't think the devel deps are needed and are much heavier).
- Use CMD instead of ENTRYPOINT. They're mostly equivalent except that for the former I can run 

```
docker run -ti gcr.io/jhoak-mini/minigo-gpu-player:0.14 /bin/sh
```

for testing.