### PR TITLE
Update the Bucket ACLs so that the service account can read the models

### DIFF
--- a/cluster/utils.sh
+++ b/cluster/utils.sh
@@ -74,8 +74,13 @@ function create_service_account_key() {
     gcloud iam service-accounts create $SERVICE_ACCOUNT --project=$PROJECT
   fi
 
-  # Grant it read/write permissions on our bucket. Should be safe to do multiple times
-  gsutil acl ch -u "${SERVICE_ACCOUNT_EMAIL}":W gs://${BUCKET_NAME}
+  # Make sure the service account can actually read the existing model entries
+  gsutil ls gs://$BUCKET_NAME/models >/dev/null 2>&1 && {{
+    gsutil acl ch -R -m -u "${SERVICE_ACCOUNT_EMAIL}":R gs://${BUCKET_NAME}/models
+  }
+
+  # Grant it write permissions on our bucket. Should be safe to do multiple times
+  gsutil acl ch -R -u "${SERVICE_ACCOUNT_EMAIL}":W gs://${BUCKET_NAME}
 
   if [[ ! -f "${SERVICE_ACCOUNT_KEY_LOCATION}" ]]; then
     echo >&2 "Service account key file doesn't exist."


### PR DESCRIPTION
This is really only a problem for bootstrap, but it is annoying.