### PR TITLE
hotfixes from 9s cluster

### DIFF
--- a/main.py
+++ b/main.py
@@ -169,7 +169,7 @@ def gather(
     with timer("Finding existing tfrecords..."):
         model_gamedata = {
             model: gfile.Glob(
-                os.path.join(input_directory, model, '**', '*.tfrecord.zz'))
+                os.path.join(input_directory, model, '*.tfrecord.zz'))
             for model in models
         }
     print("Found %d models" % len(models))

--- a/rl_loop.py
+++ b/rl_loop.py
@@ -86,11 +86,12 @@ def selfplay(readouts=1600, verbose=2, resign_threshold=0.99):
     model_save_file = os.path.join(MODELS_DIR, model_name)
     game_output_dir = os.path.join(SELFPLAY_DIR, model_name)
     game_holdout_dir = os.path.join(HOLDOUT_DIR, model_name)
+    sgf_dir = os.path.join(SGF_DIR, model_name)
     main.selfplay(
         load_file=model_save_file,
         output_dir=game_output_dir,
         holdout_dir=game_holdout_dir,
-        output_sgf=SGF_DIR,
+        output_sgf=sgf_dir,
         readouts=readouts,
         verbose=verbose,
     )


### PR DESCRIPTION
- fixes main.py to correctly list games (we no longer have a [worker] subdirectory in /data/selfplay/[model]/[worker]/[timestamp].zz)
- fixes rl_loop to call selfplay with a per-model dir to group sgfs by model (we were writing all SGFs to the same directory)