### PR TITLE
Re-add Set gpu_options.allow_growth = True

### DIFF
--- a/dual_net.py
+++ b/dual_net.py
@@ -141,7 +141,9 @@ class DualNetwork():
         self.hparams = get_default_hyperparams(**hparams)
         self.inference_input = None
         self.inference_output = None
-        self.sess = tf.Session(graph=tf.Graph())
+        config = tf.ConfigProto()
+        config.gpu_options.allow_growth = True
+        self.sess = tf.Session(graph=tf.Graph(), config=config)
         self.initialize_graph()
 
     def initialize_graph(self):


### PR DESCRIPTION
Reduces memory used for 199-lightning from 2552MiB to 523MiB.

This was added in Pull #33, but got lost.

There are a couple other tf.Session objects creates for other use cases, maybe this should be added to those also?
