### PR TITLE
Add param to strategies.MCTSPlayer.to_sgf to optionally include comments in sgf output

### DIFF
--- a/main.py
+++ b/main.py
@@ -149,7 +149,10 @@ def selfplay(
         verbose: '>=2 will print debug info, >=3 will print boards' = 1,
         resign_threshold: 'absolute value of threshold to resign at' = 0.95,
         holdout_pct: 'how many games to hold out for validation' = 0.05):
-    _ensure_dir_exists(output_sgf)
+    clean_sgf = os.path.join(output_sgf, 'clean')
+    full_sgf = os.path.join(output_sgf, 'full')
+    _ensure_dir_exists(clean_sgf)
+    _ensure_dir_exists(full_sgf)
     _ensure_dir_exists(output_dir)
     _ensure_dir_exists(holdout_dir)
 
@@ -163,7 +166,9 @@ def selfplay(
 
     output_name = '{}-{}'.format(int(time.time()), socket.gethostname())
     game_data = player.extract_data()
-    with gfile.GFile(os.path.join(output_sgf, '{}.sgf'.format(output_name)), 'w') as f:
+    with gfile.GFile(os.path.join(clean_sgf, '{}.sgf'.format(output_name)), 'w') as f:
+        f.write(player.to_sgf(use_comments=False))
+    with gfile.GFile(os.path.join(full_sgf, '{}.sgf'.format(output_name)), 'w') as f:
         f.write(player.to_sgf())
 
     tf_examples = preprocessing.make_dataset_from_selfplay(game_data)

--- a/strategies.py
+++ b/strategies.py
@@ -208,16 +208,20 @@ class MCTSPlayerMixin:
             string = self.root.position.result_string()
         self.result_string = string
 
-    def to_sgf(self):
+    def to_sgf(self, use_comments=True):
         assert self.result_string is not None
         pos = self.root.position
-        if self.comments:
-            self.comments[0] = ("Resign Threshold: %0.3f\n" %
-                                self.resign_threshold) + self.comments[0]
+        if use_comments:
+            comments = self.comments or ['No comments.']
+            comments[0] = ("Resign Threshold: %0.3f\n" %
+                                    self.resign_threshold) + comments[0]
+        else:
+            comments = []
         return sgf_wrapper.make_sgf(pos.recent, self.result_string,
                                     white_name=self.network.name or "Unknown",
                                     black_name=self.network.name or "Unknown",
-                                    comments=self.comments)
+                                    comments=comments) 
+
 
     def extract_data(self):
         assert len(self.searches_pi) == self.root.position.n


### PR DESCRIPTION
Adds functionality in main.py to save selfplay games both with and without the comments.  Fixes #88 