### PR TITLE
Fix evaluate

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -75,7 +75,8 @@ confidence=
 # --disable=W"
 
 disable=bare-except,
-        too-many-locals
+        too-many-locals,
+        too-many-arguments
         # print-statement,
         # parameter-unpacking,
         # unpacking-in-except,

--- a/evaluation.py
+++ b/evaluation.py
@@ -20,6 +20,8 @@ import sgf_wrapper
 
 from gtp_wrapper import MCTSPlayer
 
+SIMULTANEOUS_LEAVES = 8
+
 
 def play_match(black_net, white_net, games, readouts, sgf_dir, verbosity):
     """Plays matches between two neural nets.
@@ -34,9 +36,9 @@ def play_match(black_net, white_net, games, readouts, sgf_dir, verbosity):
 
     # For n games, we create lists of n black and n white players
     black = MCTSPlayer(
-        black_net, verbosity=verbosity, two_player_mode=True)
+        black_net, verbosity=verbosity, two_player_mode=True, num_parallel=SIMULTANEOUS_LEAVES)
     white = MCTSPlayer(
-        white_net, verbosity=verbosity, two_player_mode=True)
+        white_net, verbosity=verbosity, two_player_mode=True, num_parallel=SIMULTANEOUS_LEAVES)
 
     black_name = os.path.basename(black_net.save_file)
     white_name = os.path.basename(white_net.save_file)
@@ -78,13 +80,13 @@ def play_match(black_net, white_net, games, readouts, sgf_dir, verbosity):
             move = active.pick_move()
             active.play_move(move)
             inactive.play_move(move)
-            print(active.root.position)
 
             dur = time.time() - start
             num_move += 1
 
             if (verbosity > 1) or (verbosity == 1 and num_move % 10 == 9):
                 timeper = (dur / readouts) * 100.0
+                print(active.root.position)
                 print("%d: %d readouts, %.3f s/100. (%.2f sec)" % (num_move,
                                                                    readouts,
                                                                    timeper,

--- a/evaluation.py
+++ b/evaluation.py
@@ -14,84 +14,78 @@
 
 """Evalation plays games between two neural nets."""
 
+import os
 import time
+import sgf_wrapper
 
 from gtp_wrapper import MCTSPlayer
 
 
-def play_match(black_net, white_net, games, readouts, verbosity):
+def play_match(black_net, white_net, games, readouts, sgf_dir, verbosity):
     """Plays matches between two neural nets.
 
     black_net: Instance of minigo.DualNetwork, a wrapper around a tensorflow
         convolutional network.
     white_net: Instance of the minigo.DualNetwork.
     games: number of games to play. We play all the games at the same time.
+    sgf_dir: directory to write the sgf results.
     readouts: number of readouts to perform for each step in each game.
     """
 
     # For n games, we create lists of n black and n white players
-    black_players = [MCTSPlayer(
-        black_net, verbosity=verbosity, two_player_mode=True) for i in range(games)]
-    white_players = [MCTSPlayer(
-        white_net, verbosity=verbosity, two_player_mode=True) for i in range(games)]
+    black = MCTSPlayer(
+        black_net, verbosity=verbosity, two_player_mode=True)
+    white = MCTSPlayer(
+        white_net, verbosity=verbosity, two_player_mode=True)
 
-    # Each player pair represents two players that are going to play a game.
-    player_pairs = [(b, w) for b, w in zip(black_players, white_players)]
+    black_name = os.path.basename(black_net.save_file)
+    white_name = os.path.basename(white_net.save_file)
 
-    done_pairs = []
+    for i in range(games):
+        num_move = 0 # The move number of the current game
 
-    # The number of moves that have been played
-    num_moves = 0
-
-    for black, white in player_pairs:
         black.initialize_game()
         white.initialize_game()
 
-    # The heart of the game-playing loop. Each iteration through the while loop
-    # plays one move for each player. That means we:
-    #   - Do a bunch of MTCS readouts (for each active player, for each game)
-    #   - Play a move (for each active player, for each game)
-    #   - Remove any finished player-pairs
-    while player_pairs:
-        start = time.time()
+        while True:
+            start = time.time()
+            for _ in range(readouts):
+                player = white  if num_move % 2 else black
+                player.tree_search()
+                
+            # print some stats on the search
+            if verbosity >= 3:
+                print(player.root.position)
 
-        for _ in range(readouts):
-            leaves = [pair[num_moves % 2].root.select_leaf()
-                      for pair in player_pairs]
-            probs, vals = (black_net, white_net)[num_moves % 2].run_many(
-                [leaf.position for leaf in leaves])
-
-            for pair, leaf, prob, val in zip(player_pairs, leaves, probs, vals):
-                leaf.incorporate_results(
-                    prob, val, up_to=pair[num_moves % 2].root)
-
-        # print some stats on the search
-        if verbosity >= 3:
-            print(player_pairs[0][0].root.position)
-
-        for black, white in player_pairs:
-            active = white if num_moves % 2 else black
-            inactive = black if num_moves % 2 else white
+            active = white if num_move % 2 else black
+            inactive = black if num_move % 2 else white
             # First, check the roots for hopeless games.
             if active.should_resign():  # Force resign
-                continue
+                active.set_result(-1 * active.root.position.to_play, was_resign=True)
+                inactive.set_result(active.root.position.to_play, was_resign=True)
+
+            if active.is_done():
+                fname = "{:d}-{:s}-vs-{:s}-{:d}.sgf".format(int(time.time()), 
+                        white_name, black_name, i)
+                with open(os.path.join(sgf_dir, fname), 'w') as _file:
+                    sgfstr = sgf_wrapper.make_sgf(active.position.recent, 
+                            active.result_string, black_name=black_name,
+                            white_name=white_name)
+                    _file.write(sgfstr)
+                print ("Finished game", i, active.result_string)
+                break 
+
             move = active.pick_move()
             active.play_move(move)
             inactive.play_move(move)
+            print(active.root.position)
 
-        dur = time.time() - start
-        num_moves += 1
-        if (verbosity > 1) or (verbosity == 1 and num_moves % 10 == 9):
-            rdcnt = readouts * len(player_pairs)
-            timeper = dur / (readouts*len(player_pairs) / 100.0)
-            print("%d: %d readouts, %.3f s/100. (%.2f sec)" % (num_moves,
-                                                               rdcnt,
-                                                               timeper,
-                                                               dur))
+            dur = time.time() - start
+            num_move += 1
 
-        done_pairs.extend(
-            [p for p in player_pairs if p[0].is_done() or p[1].is_done()])
-        player_pairs = [p for p in player_pairs if not (
-            p[0].is_done() or p[1].is_done())]
-
-    return done_pairs
+            if (verbosity > 1) or (verbosity == 1 and num_move % 10 == 9):
+                timeper = (dur / readouts) * 100.0
+                print("%d: %d readouts, %.3f s/100. (%.2f sec)" % (num_move,
+                                                                   readouts,
+                                                                   timeper,
+                                                                   dur))

--- a/evaluation.py
+++ b/evaluation.py
@@ -44,7 +44,7 @@ def play_match(black_net, white_net, games, readouts, sgf_dir, verbosity):
     white_name = os.path.basename(white_net.save_file)
 
     for i in range(games):
-        num_move = 0 # The move number of the current game
+        num_move = 0  # The move number of the current game
 
         black.initialize_game()
         white.initialize_game()
@@ -52,9 +52,9 @@ def play_match(black_net, white_net, games, readouts, sgf_dir, verbosity):
         while True:
             start = time.time()
             for _ in range(readouts):
-                player = white  if num_move % 2 else black
+                player = white if num_move % 2 else black
                 player.tree_search()
-                
+
             # print some stats on the search
             if verbosity >= 3:
                 print(player.root.position)
@@ -63,19 +63,21 @@ def play_match(black_net, white_net, games, readouts, sgf_dir, verbosity):
             inactive = black if num_move % 2 else white
             # First, check the roots for hopeless games.
             if active.should_resign():  # Force resign
-                active.set_result(-1 * active.root.position.to_play, was_resign=True)
-                inactive.set_result(active.root.position.to_play, was_resign=True)
+                active.set_result(-1 *
+                                  active.root.position.to_play, was_resign=True)
+                inactive.set_result(
+                    active.root.position.to_play, was_resign=True)
 
             if active.is_done():
-                fname = "{:d}-{:s}-vs-{:s}-{:d}.sgf".format(int(time.time()), 
-                        white_name, black_name, i)
+                fname = "{:d}-{:s}-vs-{:s}-{:d}.sgf".format(int(time.time()),
+                                                            white_name, black_name, i)
                 with open(os.path.join(sgf_dir, fname), 'w') as _file:
-                    sgfstr = sgf_wrapper.make_sgf(active.position.recent, 
-                            active.result_string, black_name=black_name,
-                            white_name=white_name)
+                    sgfstr = sgf_wrapper.make_sgf(active.position.recent,
+                                                  active.result_string, black_name=black_name,
+                                                  white_name=white_name)
                     _file.write(sgfstr)
-                print ("Finished game", i, active.result_string)
-                break 
+                print("Finished game", i, active.result_string)
+                break
 
             move = active.pick_move()
             active.play_move(move)

--- a/local_rl_loop.py
+++ b/local_rl_loop.py
@@ -27,6 +27,7 @@ import dual_net
 import go
 import main
 from tensorflow import gfile
+import subprocess
 
 
 def rl_loop():
@@ -78,6 +79,10 @@ def rl_loop():
             output_sgf=sgf_dir,
             holdout_pct=100,
             readouts=10)
+
+        print("See sgf files here?")
+        sgf_listing = subprocess.check_output("ls -l {}/full".format(sgf_dir).split())
+        print(sgf_listing.decode("utf-8"))
 
         print("Gathering game output...")
         main.gather(input_directory=selfplay_dir, output_directory=gather_dir)

--- a/strategies.py
+++ b/strategies.py
@@ -14,6 +14,7 @@
 
 import copy
 import math
+import os
 import random
 import sys
 import time
@@ -218,9 +219,12 @@ class MCTSPlayerMixin:
         else:
             comments = []
         return sgf_wrapper.make_sgf(pos.recent, self.result_string,
-                                    white_name=self.network.name or "Unknown",
-                                    black_name=self.network.name or "Unknown",
+                                    white_name=os.path.basename(self.network.save_file) or "Unknown",
+                                    black_name=os.path.basename(self.network.save_file) or "Unknown",
                                     comments=comments) 
+
+    def is_done(self):
+        return self.result != 0 or self.root.is_done()
 
 
     def extract_data(self):


### PR DESCRIPTION
Rewrites the evaluate command to actually work w/ the new trainer rewrite and the new vlosses rewrite.

At some point, the 'name' field was removed from the DualNetwork object, although not actually removed from places that either set or referenced it.  Happily, those codepaths did not diverge...
Perhaps the player object should keep track of its semantic 'name', distinct from the filename/path used to reference its network files, and also distinct from the identifier it uses for GTP.