### PR TITLE
Estimator rewrite

### DIFF
--- a/dual_net.py
+++ b/dual_net.py
@@ -358,6 +358,9 @@ def model_fn(features, labels, mode, params, config):
 
 
     metric_ops = {
+        'accuracy': tf.metrics.accuracy(labels=labels['pi_tensor'],
+                                        predictions=policy_output,
+                                        name='accuracy_op'),
         'policy_cost': tf.metrics.mean(policy_cost),
         'value_cost': tf.metrics.mean(value_cost),
         'l2_cost': tf.metrics.mean(l2_cost),

--- a/dual_net.py
+++ b/dual_net.py
@@ -37,7 +37,7 @@ import go
 
 # How many positions to look at per generation.
 # Per AGZ, 2048 minibatch * 1k = 2M positions/generation
-EXAMPLES_PER_GENERATION = 2000
+EXAMPLES_PER_GENERATION = 2000000
 
 # How many positions can fit on a graphics card. 256 for 9s, 16 or 32 for 19s.
 TRAIN_BATCH_SIZE = 16

--- a/dual_net.py
+++ b/dual_net.py
@@ -448,6 +448,20 @@ def train(working_dir, tf_records, generation_num, **hparams):
     estimator.train(input_fn, max_steps=max_steps)
 
 
+def validate(working_dir, tf_records, checkpoint_name=None, **hparams):
+    hparams = get_default_hyperparams(**hparams)
+    estimator = tf.estimator.Estimator(
+        model_fn,
+        model_dir=working_dir,
+        params=hparams)
+    if checkpoint_name is None:
+        checkpoint_name = estimator.latest_checkpoint()
+    input_fn = lambda: preprocessing.get_input_tensors(
+        TRAIN_BATCH_SIZE, tf_records, shuffle_buffer_size=1000,
+        filter_amount=0.05)
+    estimator.evaluate(input_fn, steps=1000)
+
+
 def compute_update_ratio(weight_tensors, before_weights, after_weights):
     """Compute the ratio of gradient norm to weight norm."""
     deltas = [after - before for after,

--- a/local_rl_loop.py
+++ b/local_rl_loop.py
@@ -47,7 +47,7 @@ def rl_loop():
 
     with tempfile.TemporaryDirectory() as base_dir:
         working_dir = os.path.join(base_dir, 'models_in_training')
-        model_save_file = os.path.join(base_dir, 'models', '000000-bootstrap')
+        model_save_path = os.path.join(base_dir, 'models', '000000-bootstrap')
         next_model_save_file = os.path.join(base_dir, 'models', '000001-nextmodel')
         selfplay_dir = os.path.join(base_dir, 'data', 'selfplay')
         model_selfplay_dir = os.path.join(selfplay_dir, '000000-bootstrap')
@@ -58,24 +58,24 @@ def rl_loop():
         os.makedirs(os.path.join(base_dir, 'data'), exist_ok=True)
 
         print("Creating random initial weights...")
-        main.bootstrap(working_dir, model_save_file)
+        main.bootstrap(working_dir, model_save_path)
         print("Playing some games...")
         # Do two selfplay runs to test gather functionality
         main.selfplay(
-            load_file=model_save_file,
+            load_file=model_save_path,
             output_dir=model_selfplay_dir,
             output_sgf=sgf_dir,
             holdout_pct=0,
             readouts=10)
         main.selfplay(
-            load_file=model_save_file,
+            load_file=model_save_path,
             output_dir=model_selfplay_dir,
             output_sgf=sgf_dir,
             holdout_pct=0,
             readouts=10)
         # Do one holdout run to test validation
         main.selfplay(
-            load_file=model_save_file,
+            load_file=model_save_path,
             holdout_dir=holdout_dir,
             output_dir=model_selfplay_dir,
             output_sgf=sgf_dir,

--- a/local_rl_loop.py
+++ b/local_rl_loop.py
@@ -86,9 +86,9 @@ def rl_loop():
         main.gather(input_directory=selfplay_dir, output_directory=gather_dir)
         print("Training on gathered game data...")
         main.train(working_dir, gather_dir, next_model_save_file, generation_num=1)
-        # print("Trying validate on 'holdout' game...")
-        # main.validate(holdout_dir, load_file=model_save_file, logdir="logs")
-        print("Checking that newest checkpoint is usable...")
+        print("Trying validate on 'holdout' game...")
+        main.validate(working_dir, holdout_dir)
+        print("Verifying that new checkpoint is playable...")
         main.selfplay(
             load_file=next_model_save_file,
             holdout_dir=holdout_dir,

--- a/local_rl_loop.py
+++ b/local_rl_loop.py
@@ -46,7 +46,7 @@ def rl_loop():
     preprocessing.SHUFFLE_BUFFER_SIZE = 1000
 
     with tempfile.TemporaryDirectory() as base_dir:
-        training_dir = os.path.join(base_dir, 'models_in_training')
+        working_dir = os.path.join(base_dir, 'models_in_training')
         model_save_file = os.path.join(base_dir, 'models', '000000-bootstrap')
         next_model_save_file = os.path.join(base_dir, 'models', '000001-nextmodel')
         selfplay_dir = os.path.join(base_dir, 'data', 'selfplay')
@@ -58,7 +58,7 @@ def rl_loop():
         os.makedirs(os.path.join(base_dir, 'data'), exist_ok=True)
 
         print("Creating random initial weights...")
-        main.bootstrap(training_dir, model_save_file)
+        main.bootstrap(working_dir, model_save_file)
         print("Playing some games...")
         # Do two selfplay runs to test gather functionality
         main.selfplay(
@@ -85,7 +85,7 @@ def rl_loop():
         print("Gathering game output...")
         main.gather(input_directory=selfplay_dir, output_directory=gather_dir)
         print("Training on gathered game data...")
-        main.train(training_dir, gather_dir, next_model_save_file, generation_num=1)
+        main.train(working_dir, gather_dir, next_model_save_file, generation_num=1)
         # print("Trying validate on 'holdout' game...")
         # main.validate(holdout_dir, load_file=model_save_file, logdir="logs")
         print("Checking that newest checkpoint is usable...")

--- a/main.py
+++ b/main.py
@@ -76,16 +76,19 @@ def gtp(load_file: "The path to the network model files"=None,
             sys.stdout.flush()
 
 
-def bootstrap(working_dir, model_save_file):
-    _ensure_dir_exists(os.path.dirname(model_save_file))
+def bootstrap(
+    working_dir: 'tf.estimator working directory.',
+    model_save_path: 'Where to export the first bootstrapped generation'):
+    _ensure_dir_exists(working_dir)
+    _ensure_dir_exists(os.path.dirname(model_save_path))
     dual_net.bootstrap(working_dir)
-    dual_net.export_model(working_dir, model_save_file)
+    dual_net.export_model(working_dir, model_save_path)
 
 
 def train(
     working_dir: 'tf.estimator working directory.',
     chunk_dir: 'Directory where gathered training chunks are.',
-    model_save_file: 'Where to export the completed generation.',
+    model_save_path: 'Where to export the completed generation.',
     generation_num: 'Which generation you are training.'=0):
     tf_records = sorted(gfile.Glob(os.path.join(chunk_dir, '*.tfrecord.zz')))
     tf_records = tf_records[-1 * (WINDOW_SIZE // EXAMPLES_PER_RECORD):]
@@ -94,14 +97,14 @@ def train(
 
     with timer("Training"):
         dual_net.train(working_dir, tf_records, generation_num)
-        dual_net.export_model(working_dir, model_save_file)
+        dual_net.export_model(working_dir, model_save_path)
 
 
 def validate(
     working_dir: 'tf.estimator working directory',
-    *tf_record_dirs: 'Directory where holdout data are',
+    *tf_record_dirs: 'Directories where holdout data are',
     checkpoint_name: 'Which checkpoint to evaluate (None=latest)'=None,
-    validate_name: 'Name for validation (i.e. selfplay or professional)'=None):
+    validate_name: 'Name for validation set (i.e. selfplay or human)'=None):
     tf_records = []
     with timer("Building lists of holdout files"):
         for record_dir in tf_record_dirs:

--- a/main.py
+++ b/main.py
@@ -76,14 +76,14 @@ def gtp(load_file: "The path to the network model files"=None,
             sys.stdout.flush()
 
 
-def bootstrap(training_dir, model_save_file):
+def bootstrap(working_dir, model_save_file):
     _ensure_dir_exists(os.path.dirname(model_save_file))
-    dual_net.bootstrap(training_dir)
-    dual_net.export_model(training_dir, model_save_file)
+    dual_net.bootstrap(working_dir)
+    dual_net.export_model(working_dir, model_save_file)
 
 
 def train(
-    training_dir: 'tf.estimator working directory.',
+    working_dir: 'tf.estimator working directory.',
     chunk_dir: 'Directory where gathered training chunks are.',
     model_save_file: 'Where to export the completed generation.',
     generation_num: 'Which generation you are training.'=0):
@@ -93,8 +93,8 @@ def train(
     print("Training from:", tf_records[0], "to", tf_records[-1])
 
     with timer("Training"):
-        dual_net.train(training_dir, tf_records, generation_num)
-        dual_net.export_model(training_dir, model_save_file)
+        dual_net.train(working_dir, tf_records, generation_num)
+        dual_net.export_model(working_dir, model_save_file)
 
 
 def validate(*tf_record_dirs, load_file=None, logdir=None, num_steps=100):

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -85,7 +85,7 @@ def batch_parse_tf_example(batch_size, example_batch):
     Args:
         example_batch: a batch of tf.Example
     Returns:
-        A tuple (feature_tensor, dict of label_tensors)
+        A tuple (feature_tensor, dict of output tensors)
     '''
     features = {
         'x': tf.FixedLenFeature([], tf.string),

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -85,7 +85,7 @@ def batch_parse_tf_example(batch_size, example_batch):
     Args:
         example_batch: a batch of tf.Example
     Returns:
-        A dict of batched tensors
+        A tuple (feature_tensor, dict of label_tensors)
     '''
     features = {
         'x': tf.FixedLenFeature([], tf.string),
@@ -101,11 +101,7 @@ def batch_parse_tf_example(batch_size, example_batch):
     pi = tf.reshape(pi, [batch_size, go.N * go.N + 1])
     outcome = parsed['outcome']
     outcome.set_shape([batch_size])
-    return {
-        'pos_tensor': x,
-        'pi_tensor': pi,
-        'value_tensor': outcome,
-    }
+    return (x, {'pi_tensor': pi, 'value_tensor': outcome})
 
 
 def read_tf_records(batch_size, tf_records, num_repeats=None,

--- a/rl_loop.py
+++ b/rl_loop.py
@@ -102,7 +102,8 @@ def game_counts(n_back=20):
 def bootstrap():
     bootstrap_name = shipname.generate(0)
     bootstrap_model_path = os.path.join(MODELS_DIR, bootstrap_name)
-    print("Bootstrapping model at {}".format(bootstrap_model_path))
+    print("Bootstrapping with working dir {}\n Model 0 exported to {}".format(
+        ESTIMATOR_WORKING_DIR, bootstrap_model_path))
     main.bootstrap(ESTIMATOR_WORKING_DIR, bootstrap_model_path)
 
 
@@ -114,12 +115,12 @@ def selfplay(readouts=1600, verbose=2, resign_threshold=0.99):
         time.sleep(10*60)
         sys.exit(1)
     print("Playing a game with model {}".format(model_name))
-    model_save_file = os.path.join(MODELS_DIR, model_name)
+    model_save_path = os.path.join(MODELS_DIR, model_name)
     game_output_dir = os.path.join(SELFPLAY_DIR, model_name)
     game_holdout_dir = os.path.join(HOLDOUT_DIR, model_name)
     sgf_dir = os.path.join(SGF_DIR, model_name)
     main.selfplay(
-        load_file=model_save_file,
+        load_file=model_save_path,
         output_dir=game_output_dir,
         holdout_dir=game_holdout_dir,
         output_sgf=sgf_dir,

--- a/rl_loop.py
+++ b/rl_loop.py
@@ -35,6 +35,8 @@ HOLDOUT_DIR = os.path.join(BASE_DIR, 'data/holdout')
 SGF_DIR = os.path.join(BASE_DIR, 'sgf')
 TRAINING_CHUNK_DIR = os.path.join(BASE_DIR, 'data', 'training_chunks')
 
+ESTIMATOR_WORKING_DIR = 'estimator_working_dir'
+
 # How many games before the selfplay workers will stop trying to play more.
 MAX_GAMES_PER_GENERATION = 10000
 
@@ -51,6 +53,7 @@ def print_flags():
         'HOLDOUT_DIR': HOLDOUT_DIR,
         'SGF_DIR': SGF_DIR,
         'TRAINING_CHUNK_DIR': TRAINING_CHUNK_DIR,
+        'ESTIMATOR_WORKING_DIR': ESTIMATOR_WORKING_DIR,
     }
     print("Computed variables are:")
     print('\n'.join('--{}={}'.format(flag, value)
@@ -100,7 +103,7 @@ def bootstrap():
     bootstrap_name = shipname.generate(0)
     bootstrap_model_path = os.path.join(MODELS_DIR, bootstrap_name)
     print("Bootstrapping model at {}".format(bootstrap_model_path))
-    main.bootstrap(bootstrap_model_path)
+    main.bootstrap(ESTIMATOR_WORKING_DIR, bootstrap_model_path)
 
 
 def selfplay(readouts=1600, verbose=2, resign_threshold=0.99):
@@ -133,7 +136,7 @@ def gather():
                 output_directory=TRAINING_CHUNK_DIR)
 
 
-def train(logdir=None):
+def train():
     model_num, model_name = get_latest_model()
     print("Training on gathered game data, initializing from {}".format(model_name))
     new_model_name = shipname.generate(model_num + 1)
@@ -141,14 +144,14 @@ def train(logdir=None):
     load_file = os.path.join(MODELS_DIR, model_name)
     save_file = os.path.join(MODELS_DIR, new_model_name)
     try:
-        main.train(TRAINING_CHUNK_DIR, save_file=save_file, load_file=load_file,
-                   generation_num=model_num, logdir=logdir)
+        main.train(ESTIMATOR_WORKING_DIR, TRAINING_CHUNK_DIR, save_file,
+                   generation_num=model_num + 1)
     except:
         print("Got an error training, muddling on...")
         logging.exception("Train error")
 
 
-def validate(logdir=None, model_num=None):
+def validate(model_num=None, validate_name=None):
     """ Runs validate on the directories up to the most recent model, or up to
     (but not including) the model specified by `model_num`
     """
@@ -164,12 +167,13 @@ def validate(logdir=None, model_num=None):
     models = list(
         filter(lambda num_name: num_name[0] < (model_num - 1), get_models()))
     # Run on the most recent 50 generations,
+    # TODO(brianklee): make this hyperparameter dependency explicit/not hardcoded
     holdout_dirs = [os.path.join(HOLDOUT_DIR, pair[1])
                     for pair in models[-50:]]
 
-    main.validate(*holdout_dirs,
-                  load_file=os.path.join(MODELS_DIR, model_name),
-                  logdir=logdir)
+    main.validate(ESTIMATOR_WORKING_DIR, *holdout_dirs,
+                  checkpoint_name=os.path.join(MODELS_DIR, model_name),
+                  validate_name=validate_name)
 
 
 parser = argparse.ArgumentParser()

--- a/rl_runner.py
+++ b/rl_runner.py
@@ -20,17 +20,16 @@ If the gather job dies more than three times, we quit entirely.
 
 import subprocess
 import sys
-import argh
 from utils import timer
 
 
-def loop(logdir=None):
+def loop():
     """Run gather and train as subprocesses."""
     gather_errors = 0
     while True:
         print("==================================")
         with timer("Gather"):
-            gather = subprocess.call("python rl_loop.py gather".split())
+            gather = subprocess.call("python rl_loop.py gather", shell=True)
             if gather != 0:
                 print("Error in gather, retrying")
                 gather_errors += 1
@@ -41,13 +40,11 @@ def loop(logdir=None):
         gather_errors = 0
 
         with timer("Train"):
-            subprocess.call(
-                ("python rl_loop.py train --logdir=%s" % logdir).split())
+            subprocess.call("python rl_loop.py train", shell=True)
 
         with timer("validate"):
-            subprocess.call(
-                ("python rl_loop.py validate --logdir=%s" % logdir).split())
+            subprocess.call("python rl_loop.py validate", shell=True)
 
 
 if __name__ == '__main__':
-    argh.dispatch_command(loop)
+    loop()

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -39,18 +39,18 @@ class TestPreprocessing(test_utils.MiniGoUnitTest):
         return raw_data
 
     def extract_data(self, tf_record, filter_amount=1):
-        tf_example_tensor = preprocessing.get_input_tensors(
+        pos_tensor, label_tensors = preprocessing.get_input_tensors(
             1, [tf_record], num_repeats=1, shuffle_records=False,
             shuffle_examples=False, filter_amount=filter_amount)
         recovered_data = []
         with tf.Session() as sess:
             while True:
                 try:
-                    values = sess.run(tf_example_tensor)
+                    pos_value, label_values = sess.run([pos_tensor, label_tensors])
                     recovered_data.append((
-                        values['pos_tensor'],
-                        values['pi_tensor'],
-                        values['value_tensor']))
+                        pos_value,
+                        label_values['pi_tensor'],
+                        label_values['value_tensor']))
                 except tf.errors.OutOfRangeError:
                     break
         return recovered_data


### PR DESCRIPTION
Estimator rewrite!

Rough outline: training occurs locally, with checkpointing happening automatically. After a fixed number of steps, as calculated by generation number, we take the latest exported checkpoint on disk and copy it to GCS, where the selfplay workers pick it up.

All logging is confirmed working, including a sessionrunhook to calculate update ratios. Apparently Estimator throws in a "steps per second" logger for free, too. Validation now has a nice framework under which to classify selfplay vs. pro dataset validation.

There's some continued hyperparameter ugliness; my next task will be to clean all this up.