### PR TITLE
Add flags infrastructure to main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,6 +23,7 @@ import socket
 import sys
 import tempfile
 import time
+from absl import flags
 import cloud_logging
 from tqdm import tqdm
 import gzip
@@ -269,4 +270,8 @@ argh.add_commands(parser, [gtp, bootstrap, train,
 
 if __name__ == '__main__':
     cloud_logging.configure()
-    argh.dispatch(parser)
+    # Let absl.flags parse known flags from argv, then pass the remaining flags
+    # into argh for dispatching.
+    remaining_argv = flags.FLAGS(sys.argv, known_only=True)
+    print(remaining_argv)
+    argh.dispatch(parser, argv=remaining_argv[1:])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+absl-py
 argh
 autopep8>=1.3
 google.cloud.logging


### PR DESCRIPTION
This is a deceptively simple PR that took me like 5 hours of researching the interaction between argparse, arghparse, and absl.flags and trying to figure out how to create a flag file.

Anyway, this is the first commit. This is backwards compatible with the way we've been calling everything, and allows us to gradually swap out hyperparameters one by one by replacing them with flags.DEFINE declarations. I'll submit a few of these as examples on how to swap them out.

The only downside I've found so far is that this approach doesn't allow directly loading flagfiles from GCS; they must be gsutil cp'd to the host before passing --flagfile=local/path/to/flagfile as a command line flag.