### PR TITLE
Set default minigui backend to the python impl (avoids blaze build dep)

### DIFF
--- a/minigui/README.md
+++ b/minigui/README.md
@@ -6,6 +6,8 @@
 
 1. Download a model from our [public bucket](https://console.cloud.google.com/storage/browser/minigo-pub) and set the path appropriately in `serve.py` where it says `MODEL_PATH = ...`. 
 
+1. Set the board size variables appropriately in `serve.py` and in `minigui.ts`. [TODO: make this board size detection automatic](https://github.com/tensorflow/minigo/issues/175)
+
 1. Make sure the command at the top of `serve.py` actually runs and prints `GTP engine ready`; if not, something is wrong with the rest of the minigo setup, like virtualenv or similar.
 
 1. Compile the typescript. (Requires [typescript compiler](https://www.typescriptlang.org/#download-links)). Running `cd minigui; tsc` should find and compile the relevant files.

--- a/minigui/serve.py
+++ b/minigui/serve.py
@@ -23,22 +23,24 @@ socketio = SocketIO(app)
 
 #TODO(amj) extract to flag
 MODEL_PATH = "saved_models/000483-indus-upgrade"
+# If you change this BOARD_SIZE variable, also change the line at the top of
+# minigui.ts that says const N = board.BoardSize.Nine
 BOARD_SIZE = "19"  # Models are hardcoded to a board size.
 
-# GTP_COMMAND = ["python",  "-u",  # turn off buffering
-#                "main.py", "gtp",
-#                "--load-file", MODEL_PATH,
-#                "--readouts", "1000",
-#                "-v", "2"]
+GTP_COMMAND = ["python",  "-u",  # turn off buffering
+               "main.py", "gtp",
+               "--load-file", MODEL_PATH,
+               "--readouts", "1000",
+               "-v", "2"]
 
-GTP_COMMAND = [
-    "bazel-bin/cc/main",
-    "--model=" + MODEL_PATH + ".pb",
-    "--num_readouts=100",
-    "--soft_pick=false",
-    "--inject_noise=false",
-    "--disable_resign_pct=0",
-    "--mode=gtp"]
+# GTP_COMMAND = [
+#     "bazel-bin/cc/main",
+#     "--model=" + MODEL_PATH + ".pb",
+#     "--num_readouts=100",
+#     "--soft_pick=false",
+#     "--inject_noise=false",
+#     "--disable_resign_pct=0",
+#     "--mode=gtp"]
 
 
 def _open_pipes():


### PR DESCRIPTION
(Setting it to python for now; i'll dig around with bazel building and write up instructions in the future.)