### PR TITLE
Scale c_puct based on abs(Q)

### DIFF
--- a/cc/BUILD
+++ b/cc/BUILD
@@ -117,6 +117,7 @@ minigo_cc_library(
         ":random",
         ":symmetries",
         "//cc/dual_net",
+        "@com_github_gflags_gflags//:gflags",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/time",
         "@com_google_absl//absl/types:span",

--- a/cc/mcts_node.h
+++ b/cc/mcts_node.h
@@ -27,6 +27,10 @@
 #include "cc/constants.h"
 #include "cc/position.h"
 
+#include "gflags/gflags.h"
+
+DECLARE_double(scaling_puct_strength);
+
 namespace minigo {
 
 class MctsNode {


### PR DESCRIPTION
```
competition_type = 'playoff'

description = """ Testing various minigo models """

record_games = True
stderr_to_log = True

BASE_FLAGS = " --resign_threshold=-0.95 --num_readouts=400 "
CC_FLAGS = " --mode=gtp --virtual_losses=8 --soft_pick=false --inject_noise=false --courtesy_pass=false "
ALL_FLAGS = CC_FLAGS + BASE_FLAGS

def cc_player(scaling):
    return Player(
        "bazel-bin/cc/main" + ALL_FLAGS + " --model=models/000303-olympus.pb -scaling_puct_strength=" + scaling,
        cwd="~/Projects/minigo/")

players = {
    'minigo-default'  :  cc_player('0'),
    'minigo-dynamic'  :  cc_player('1.5'),
    'minigo-negativ'  :  cc_player('-0.4'),
}

board_size = 19
komi = 7.5

matchups = [
    Matchup('minigo-default', 'minigo-dynamic', alternating=True, scorer='players', number_of_games=300),
    Matchup('minigo-default', 'minigo-negativ', alternating=True, scorer='players', number_of_games=300),
]
```

Some random experiments, similar to dynamic q in leela
