### PR TITLE
Fix UCB for both python and C++

### DIFF
--- a/cc/mcts_node.cc
+++ b/cc/mcts_node.cc
@@ -246,6 +246,7 @@ void MctsNode::AddVirtualLoss(MctsNode* up_to) {
   auto* node = this;
   do {
     ++node->num_virtual_losses_applied;
+    node->stats->W += node->position.to_play() == Color::kBlack ? 1 : -1;
     node = node->parent;
   } while (node != nullptr && node != up_to);
 }
@@ -254,6 +255,7 @@ void MctsNode::RevertVirtualLoss(MctsNode* up_to) {
   auto* node = this;
   do {
     --node->num_virtual_losses_applied;
+    node->stats->W -= node->position.to_play() == Color::kBlack ? 1 : -1;
     node = node->parent;
   } while (node != nullptr && node != up_to);
 }
@@ -267,7 +269,7 @@ void MctsNode::PruneChildren(Coord c) {
 
 std::array<float, kNumMoves> MctsNode::CalculateChildActionScore() const {
   float to_play = position.to_play() == Color::kBlack ? 1 : -1;
-  float U_scale = kPuct * std::sqrt(1.0f + N());
+  float U_scale = kPuct * std::sqrt(std::max<float>(1, N() - 1));
 
   std::array<float, kNumMoves> result;
   for (int i = 0; i < kNumMoves; ++i) {

--- a/cc/mcts_node.h
+++ b/cc/mcts_node.h
@@ -53,11 +53,7 @@ class MctsNode {
   float W() const { return stats->W; }
   float P() const { return stats->P; }
   float original_P() const { return stats->original_P; }
-  // float Q() const { return W() / (1 + N()); }
-  float Q() const {
-    return W() - (position.to_play() * num_virtual_losses_applied) /
-                     (1 + N() + num_virtual_losses_applied);
-  }
+  float Q() const { return W() / (1 + N()); }
   float Q_perspective() const {
     return position.to_play() == Color::kBlack ? Q() : -Q();
   }
@@ -65,16 +61,11 @@ class MctsNode {
   float child_N(int i) const { return edges[i].N; }
   float child_W(int i) const { return edges[i].W; }
   float child_P(int i) const { return edges[i].P; }
-  float child_vlosses(int i) const {
-    return edges[i].num_virtual_losses_applied;
-  }
   float child_original_P(int i) const { return edges[i].original_P; }
-  float child_Q(int i) const {
-    return (child_W(i) + position.to_play() * child_vlosses(i)) /
-           (1 + child_N(i) + child_vlosses(i));
-  }
+  float child_Q(int i) const { return child_W(i) / (1 + child_N(i)); }
   float child_U(int i) const {
-    return kPuct * std::sqrt(1.0f + N()) * child_P(i) / (1 + child_N(i));
+    return kPuct * std::sqrt(std::max<float>(1, N() - 1)) * child_P(i) /
+           (1 + child_N(i));
   }
 
   std::string Describe() const;

--- a/cc/mcts_node.h
+++ b/cc/mcts_node.h
@@ -53,7 +53,11 @@ class MctsNode {
   float W() const { return stats->W; }
   float P() const { return stats->P; }
   float original_P() const { return stats->original_P; }
-  float Q() const { return W() / (1 + N()); }
+  // float Q() const { return W() / (1 + N()); }
+  float Q() const {
+    return W() - (position.to_play() * num_virtual_losses_applied) /
+                     (1 + N() + num_virtual_losses_applied);
+  }
   float Q_perspective() const {
     return position.to_play() == Color::kBlack ? Q() : -Q();
   }
@@ -61,8 +65,14 @@ class MctsNode {
   float child_N(int i) const { return edges[i].N; }
   float child_W(int i) const { return edges[i].W; }
   float child_P(int i) const { return edges[i].P; }
+  float child_vlosses(int i) const {
+    return edges[i].num_virtual_losses_applied;
+  }
   float child_original_P(int i) const { return edges[i].original_P; }
-  float child_Q(int i) const { return child_W(i) / (1 + child_N(i)); }
+  float child_Q(int i) const {
+    return (child_W(i) + position.to_play() * child_vlosses(i)) /
+           (1 + child_N(i) + child_vlosses(i));
+  }
   float child_U(int i) const {
     return kPuct * std::sqrt(1.0f + N()) * child_P(i) / (1 + child_N(i));
   }
@@ -90,14 +100,6 @@ class MctsNode {
                           float value, MctsNode* up_to);
 
   void IncorporateEndGameResult(float value, MctsNode* up_to);
-
-  // Sometimes, repeated calls to select_leaf return the same node.  This is
-  // rare and we're okay with the wasted computation to evaluate the position
-  // multiple times by the dual_net. But select_leaf has the side effect of
-  // incrementing visit counts. Since we want the value to only count once for
-  // the repeatedly selected node, we also have to revert the incremented visit
-  // counts.
-  void RevertVisits(MctsNode* up_to);
 
   void BackupValue(float value, MctsNode* up_to);
 

--- a/mcts.py
+++ b/mcts.py
@@ -103,7 +103,7 @@ class MCTSNode(object):
 
     @property
     def child_U(self):
-        return (FLAGS.c_puct * math.sqrt(1 + self.N) *
+        return (FLAGS.c_puct * math.sqrt(max(1, self.N-1)) *
                 self.child_prior / (1 + self.child_N))
 
     @property
@@ -135,7 +135,6 @@ class MCTSNode(object):
         current = self
         pass_move = go.N * go.N
         while True:
-            current.N += 1
             # if a node has never been evaluated, we have no basis to select a child.
             if not current.is_expanded:
                 break
@@ -184,28 +183,15 @@ class MCTSNode(object):
             return
         self.parent.revert_virtual_loss(up_to)
 
-    def revert_visits(self, up_to):
-        """Revert visit increments.
-
-        Sometimes, repeated calls to select_leaf return the same node.
-        This is rare and we're okay with the wasted computation to evaluate
-        the position multiple times by the dual_net. But select_leaf has the
-        side effect of incrementing visit counts. Since we want the value to
-        only count once for the repeatedly selected node, we also have to
-        revert the incremented visit counts.
-        """
-        self.N -= 1
-        if self.parent is None or self is up_to:
-            return
-        self.parent.revert_visits(up_to)
-
     def incorporate_results(self, move_probabilities, value, up_to):
         assert move_probabilities.shape == (go.N * go.N + 1,)
         # A finished game should not be going through this code path - should
         # directly call backup_value() on the result of the game.
         assert not self.position.is_game_over()
+
+        # If a node was picked multiple times (despite vlosses), we shouldn't
+        # expand it more than once.
         if self.is_expanded:
-            self.revert_visits(up_to=up_to)
             return
         self.is_expanded = True
 
@@ -235,6 +221,7 @@ class MCTSNode(object):
             value: the value to be propagated (1 = black wins, -1 = white wins)
             up_to: the node to propagate until.
         """
+        self.N += 1
         self.W += value
         if self.parent is None or self is up_to:
             return


### PR DESCRIPTION
- Perform visit incrementing on backup, not on selection
- Apply vloss by just tweaking W.
- remove dead `revert_visits` code.
