### PR TITLE
flag and docker changes for v10

### DIFF
--- a/cluster/cluster-up-tpu.sh
+++ b/cluster/cluster-up-tpu.sh
@@ -20,8 +20,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source ${SCRIPT_DIR}/common.sh
 source ${SCRIPT_DIR}/utils.sh
 
-export NUM_NODES=2
-export CLUSTER_NAME=minigo-tpu
+export NUM_NODES=128
 ZONE=us-central1-f
 
 echo "TPU Cluster Creation"
@@ -34,17 +33,19 @@ echo "Overriding num nodes to: $NUM_NODES"
 
 check_gcloud_exists
 
+#gcloud compute networks create $CLUSTER_NAME
+
 # Create a Kubernetes cluster. This setup is designed for creating large clusters.
 gcloud beta container clusters create \
     --project=$PROJECT \
     --zone=$ZONE \
     --cluster-version=1.10 \
     --scopes=cloud-platform \
-    --create-subnetwork name=tpu-cluster,range=/18 \
+    --network=$CLUSTER_NAME \
     --enable-ip-alias \
     --enable-tpu \
     --machine-type n1-standard-16 \
-    --disk-size 60 \
+    --disk-size 45 \
     --num-nodes $NUM_NODES \
     $CLUSTER_NAME
     #--tpu-ipv4-cidr=/18 \

--- a/cluster/evaluator/Dockerfile-cc
+++ b/cluster/evaluator/Dockerfile-cc
@@ -1,5 +1,8 @@
-FROM gcr.io/$PROJECT/cc-base:0.17
+FROM gcr.io/tensor-go/cc-base:0.17
 
 COPY evaluator_cc_wrapper.sh /app
+
+ADD staging/ /app
+RUN bazel build -c opt --define=board_size=19 --define=tf=1 remote=0 cc/main
 
 CMD ["/bin/sh", "evaluator_cc_wrapper.sh"]

--- a/cluster/evaluator/launch_eval.py
+++ b/cluster/evaluator/launch_eval.py
@@ -26,7 +26,7 @@ import fsdb
 import time
 
 
-def launch_eval_job(m1_path, m2_path, job_name, bucket_name, completions=20):
+def launch_eval_job(m1_path, m2_path, job_name, bucket_name, completions=2):
     """Launches an evaluator job.
     m1_path, m2_path: full gs:// paths to the .pb files to match up
     job_name: string, appended to the container, used to differentiate the job names

--- a/cluster/selfplay/Dockerfile.tpu
+++ b/cluster/selfplay/Dockerfile.tpu
@@ -34,5 +34,5 @@ RUN pip3 install "tensorflow==1.9.0rc2"
 ADD staging/ /app
 WORKDIR /app
 
-RUN bazel build -c opt cc:main
+RUN bazel build -c opt --define=board_size=19 --define=remote=1 cc/main
 CMD ["/bin/sh", "tpu_wrapper.sh"]

--- a/cluster/selfplay/tpu-player-deployment.yaml
+++ b/cluster/selfplay/tpu-player-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: tpu-player-deployment
 spec:
-  replicas: 8
+  replicas: 128
   selector:
     matchLabels:
       app: tpu-player
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: minigo-tpu-player-container
-        image: gcr.io/tensor-go/minigo-tpu-player:0.2
+        image: gcr.io/tensor-go/minigo-tpu-player:0.21
         imagePullPolicy: Always
         resources:
           limits:
@@ -25,6 +25,8 @@ spec:
         - name: service-credentials
           mountPath: /etc/credentials
         env:
+        - name: GCS_READ_CACHE_MAX_SIZE_MB
+          value: "0"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/credentials/service-account.json
         - name: BUCKET_NAME

--- a/cluster/selfplay/tpu_wrapper.sh
+++ b/cluster/selfplay/tpu_wrapper.sh
@@ -22,13 +22,12 @@ set -e
 : ${WORK_DIR?"Working directory must be set!"}
 
 bazel-bin/cc/main \
-  --remote_inference=true \
+  --engine=remote \
   --checkpoint-dir=${WORK_DIR}\
   --inject_noise=true \
   --soft_pick=true \
   --random_symmetry=true \
   --virtual_losses=8 \
-  --games_per_inference=16 \
   --parallel_games=32 \
   --num_readouts=800 \
   --resign_threshold=-0.999 \
@@ -37,4 +36,5 @@ bazel-bin/cc/main \
   --holdout_dir=gs://${BUCKET_NAME}/data/holdout \
   --sgf_dir=gs://${BUCKET_NAME}/sgf \
   --mode=selfplay \
+  --flags_path=gs://${BUCKET_NAME}/flags.txt
   --run_forever=true

--- a/rl_runner.py
+++ b/rl_runner.py
@@ -43,7 +43,9 @@ def loop(working_dir='estimator_working_dir', tpu_name=None):
             train = subprocess.call(['python', 'rl_loop.py', 'train'] + flags)
             if train != 0:
                 print("Skipping validation")
+                print("!!!")
                 print("=== Training failed at ", dt.datetime.utcnow())
+                print("!!!")
                 sys.exit(1)
                 continue
 


### PR DESCRIPTION
- Changes TPU_wrapper.sh to call cc binary with correct flags
- Changes tpu_up script to create separate networks
- Updates dockerfile to add build args for correct backend.
- Fixes #395 , adding env var to k8s config for tpu job to disable gcs caching