### PR TITLE
Replace argh library with fire library.

### DIFF
--- a/cluster/evaluator/launch_eval.py
+++ b/cluster/evaluator/launch_eval.py
@@ -15,13 +15,12 @@
 import sys
 sys.path.insert(0, '.')
 
+import fire
 from absl import flags
 import kubernetes
-import argparse
 import yaml
 import json
 import os
-import argh
 import fsdb
 import time
 
@@ -196,9 +195,11 @@ def make_pairs_for_model(model_num=0):
     return pairs
 
 
-parser = argparse.ArgumentParser()
-argh.add_commands(parser, [zoo_loop, same_run_eval, cleanup, launch_eval_job])
-
 if __name__ == '__main__':
     remaining_argv = flags.FLAGS(sys.argv, known_only=True)
-    argh.dispatch(parser, argv=remaining_argv[1:])
+    fire.Fire({
+        'zoo_loop': zoo_loop,
+        'same_run_eval': same_run_eval,
+        'cleanup': cleanup,
+        'launch_eval_job': launch_eval_job,
+    }, remaining_argv[1:])

--- a/dual_net.py
+++ b/dual_net.py
@@ -19,12 +19,11 @@ move prediction and score estimation.
 """
 
 from absl import flags
-import argparse
 import functools
 import os.path
 import sys
 
-import argh
+import fire
 from tqdm import tqdm
 import numpy as np
 import tensorflow as tf
@@ -616,11 +615,12 @@ class UpdateRatioSessionHook(tf.train.SessionRunHook):
             self.before_weights = None
 
 
-parser = argparse.ArgumentParser()
-argh.add_commands(parser, [train, export_model, validate])
-
 if __name__ == '__main__':
     # Let absl.flags parse known flags from argv, then pass the remaining flags
-    # into argh for dispatching.
+    # into 'fire' for dispatching.
     remaining_argv = flags.FLAGS(sys.argv, known_only=True)
-    argh.dispatch(parser, argv=remaining_argv[1:])
+    fire.Fire({
+        'train': train,
+        'export_model': export_model,
+        'validate': validate,
+    }, remaining_argv[1:])

--- a/example_buffer.py
+++ b/example_buffer.py
@@ -1,6 +1,5 @@
-import argh
-import argparse
 import datetime as dt
+import fire
 import functools
 import itertools
 import multiprocessing as mp
@@ -303,11 +302,12 @@ def make_chunk_for(output_dir=LOCAL_DIR,
     buf.flush(output)
 
 
-parser = argparse.ArgumentParser()
-argh.add_commands(parser, [fill_and_wait_models, fill_and_wait_time,
-                           smart_rsync, make_chunk_for])
-
 if __name__ == "__main__":
     import sys
     remaining_argv = flags.FLAGS(sys.argv, known_only=True)
-    argh.dispatch(parser, argv=remaining_argv[1:])
+    fire.Fire({
+        'fill_and_wait_models': fill_and_wait_models,
+        'fill_and_wait_time': fill_and_wait_time,
+        'smart_rsync': smart_rsync,
+        'make_chunk_for': make_chunk_for,
+    }, remaining_argv[1:])

--- a/main.py
+++ b/main.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import argh
-import argparse
+import fire
 import os.path
 import sys
 import tempfile
@@ -145,13 +144,17 @@ def freeze_graph(load_file):
         f.write(out_graph.SerializeToString())
 
 
-parser = argparse.ArgumentParser()
-argh.add_commands(parser, [bootstrap, train, train_dir, freeze_graph,
-                           evaluate, validate, convert])
-
 if __name__ == '__main__':
     cloud_logging.configure()
     # Let absl.flags parse known flags from argv, then pass the remaining flags
-    # into argh for dispatching.
+    # into 'fire' for dispatching.
     remaining_argv = flags.FLAGS(sys.argv, known_only=True)
-    argh.dispatch(parser, argv=remaining_argv[1:])
+    fire.Fire({
+        'bootstrap': bootstrap,
+        'train': train,
+        'train_dir': train_dir,
+        'freeze_graph': freeze_graph,
+        'evaluate': evaluate,
+        'validate': validate,
+        'convert': convert,
+    }, remaining_argv[1:])

--- a/oneoffs/resign_analysis.py
+++ b/oneoffs/resign_analysis.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import argh
+import fire
 import os
 import itertools
 import re
@@ -86,4 +86,4 @@ def crawl(sgf_directory='sgf', print_summary=True):
         print (bad_resign_files)
 
 if __name__ == '__main__':
-    argh.dispatch_command(crawl)
+    fire.Fire(crawl)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 absl-py
 argh
 autopep8>=1.3
+fire
 google.cloud.logging
 grpcio-tools
 numpy>=1.14.0

--- a/rl_loop.py
+++ b/rl_loop.py
@@ -13,14 +13,13 @@
 # limitations under the License.
 
 """Bookkeeping around other entry points to automate the rl pipeline."""
-import argparse
 import logging
 import os
 import sys
 import time
 
+import fire
 from absl import flags
-import argh
 from tensorflow import gfile
 import itertools
 import random
@@ -158,13 +157,15 @@ def backfill():
             continue
 
 
-parser = argparse.ArgumentParser()
-
-argh.add_commands(parser, [train, selfplay, backfill,
-                           bootstrap, fsdb.game_counts, validate,
-                           validate_hourly])
-
 if __name__ == '__main__':
     cloud_logging.configure()
     remaining_argv = flags.FLAGS(sys.argv, known_only=True)
-    argh.dispatch(parser, argv=remaining_argv[1:])
+    fire.Fire({
+        'train': train,
+        'selfplay': selfplay,
+        'backfill': backfill,
+        'bootstrap': bootstrap,
+        'game_counts': fsdb.game_counts,
+        'validate': validate,
+        'validate_hourly': validate_hourly,
+    }, remaining_argv[1:])

--- a/rl_runner.py
+++ b/rl_runner.py
@@ -18,11 +18,11 @@ We run as subprocesses because it gives us some isolation.
 """
 
 import datetime as dt
+import fire
 import os
 import subprocess
 import sys
 
-import argh
 from utils import timer
 
 BUCKET_NAME = os.environ['BUCKET_NAME']
@@ -57,4 +57,4 @@ def loop(working_dir='estimator_working_dir', tpu_name=None):
 
 
 if __name__ == '__main__':
-    argh.dispatch_command(loop)
+    fire.Fire(loop)


### PR DESCRIPTION
Fire is slightly more straightforward for minigo's usage
since everything can be passed directly to the fire.Fire()
rather than indirectly through argh.add_commands().

argparse usage is also hidden and doesn't need to be
imported separately and used as a proxy.