### PR TITLE
Use GPUs (in TfDualNet) only when --define=gpu=1 is set.

### DIFF
--- a/cc/config/BUILD
+++ b/cc/config/BUILD
@@ -39,3 +39,8 @@ config_setting(
     name = "enable_bt",
     define_values = {"bt": "1"},
 )
+
+config_setting(
+    name = "enable_gpu",
+    define_values = {"gpu": "1"},
+)

--- a/cc/dual_net/BUILD
+++ b/cc/dual_net/BUILD
@@ -97,6 +97,10 @@ minigo_cc_library(
     name = "tf_dual_net",
     srcs = ["tf_dual_net.cc"],
     hdrs = ["tf_dual_net.h"],
+    copts = select({
+        "//cc/config:enable_gpu": ["-DMINIGO_ENABLE_GPU=1"],
+        "//conditions:default": [],
+    }),
     tags = ["manual"],
     deps = [
         ":dual_net",


### PR DESCRIPTION
This is a hopefully less intrusive variant of PR #490.