### PR TITLE
Trainer job fixes

### DIFF
--- a/bigtable_input.py
+++ b/bigtable_input.py
@@ -485,26 +485,25 @@ class GameQueue:
                 print('  games/sec:', len(h)/elapsed)
 
 
-def set_fresh_watermark(games, window_size, fresh_fraction=0.05, minimum_fresh=20000):
+def set_fresh_watermark(game_queue, latest_game, window_size, fresh_fraction=0.05, minimum_fresh=20000):
     """Sets the metadata cell used to block until some quantity of games have been played.
 
-    This sets the 'high water mark' on the `games` queue, used to block training
+    This sets the 'high water mark' on the `game_queue`, used to block training
     until enough new games have been played.  The number of fresh games required
     is the larger of:
        - The fraction of the total window size
        - The `minimum_fresh` parameter
     Args:
-      games: A GameQueue object, on whose backing table will be modified.
+      game_queue: A GameQueue object, on whose backing table will be modified.
       window_size:  an integer indicating how many past games are considered
       fresh_fraction: a float in (0,1] indicating the fraction of games to wait for
       minimum_fresh:  an integer indicating the lower bound on the number of new
       games.
     """
-    latest_game = games.latest_game_number
     if window_size > latest_game: # How to handle the case when the window is not yet 'full'
-        games.require_fresh_games(int(minimum_fresh * .9))
+        game_queue.require_fresh_games(int(minimum_fresh * .9))
     else:
-        games.require_fresh_games(
+        game_queue.require_fresh_games(
                 math.ceil(window_size * .9 * fresh_fraction))
 
 

--- a/bigtable_input.py
+++ b/bigtable_input.py
@@ -338,8 +338,8 @@ class GameQueue:
         if not wait_until_game:
             return
         latest_game = self.latest_game_number
+        last_latest = latest_game
         while latest_game < wait_until_game:
-            last_latest = latest_game
             utils.dbg('Latest game {} not yet at required game {} '
                       '(+{}, {:0.3f} games/sec)'.format(
                               latest_game,
@@ -348,6 +348,7 @@ class GameQueue:
                               (latest_game - last_latest) / poll_interval
                       ))
             time.sleep(poll_interval)
+            last_latest = latest_game
             latest_game = self.latest_game_number
 
     def read_wait_cell(self):

--- a/bigtable_input.py
+++ b/bigtable_input.py
@@ -339,8 +339,14 @@ class GameQueue:
             return
         latest_game = self.latest_game_number
         while latest_game < wait_until_game:
-            utils.dbg('Latest game {} not yet at required game {}'.
-                      format(latest_game, wait_until_game))
+            last_latest = latest_game
+            utils.dbg('Latest game {} not yet at required game {} '
+                      '(+{}, {:0.3f} games/sec)'.format(
+                              latest_game,
+                              wait_until_game,
+                              latest_game - last_latest,
+                              (latest_game - last_latest) / poll_interval
+                      ))
             time.sleep(poll_interval)
             latest_game = self.latest_game_number
 

--- a/bigtable_input.py
+++ b/bigtable_input.py
@@ -504,7 +504,7 @@ def set_fresh_watermark(games, window_size, fresh_fraction=0.05, minimum_fresh=2
         games.require_fresh_games(int(minimum_fresh * .9))
     else:
         games.require_fresh_games(
-                math.ceil(n * .9 * fresh_fraction))
+                math.ceil(window_size * .9 * fresh_fraction))
 
 
 def get_unparsed_moves_from_last_n_games(games, games_nr, n,

--- a/bigtable_input.py
+++ b/bigtable_input.py
@@ -322,6 +322,7 @@ class GameQueue:
         table_state = self.bt_table.row(TABLE_STATE)
         table_state.set_cell(METADATA, WAIT_CELL, int(latest + number_fresh))
         table_state.commit()
+        print("== Setting wait cell to ", int(latest + number_fresh), flush=True)
 
     def wait_for_fresh_games(self, poll_interval=15.0):
         """Block caller until required new games have been played.
@@ -502,10 +503,12 @@ def set_fresh_watermark(game_queue, count_from, window_size, fresh_fraction=0.05
       games.
     """
     already_played = game_queue.latest_game_number - count_from
+    print("== already_played: ", already_played, flush=True)
     if window_size > count_from: # How to handle the case when the window is not yet 'full'
         game_queue.require_fresh_games(int(minimum_fresh * .9))
     else:
         num_to_play = max(0, math.ceil(window_size * .9 * fresh_fraction) - already_played)
+        print("== Num to play: ", num_to_play, flush=True)
         game_queue.require_fresh_games(num_to_play)
 
 

--- a/cluster/trainer/Dockerfile
+++ b/cluster/trainer/Dockerfile
@@ -10,4 +10,4 @@ COPY staging /app
 COPY staging/rl_loop/ /app
 COPY staging/mask_flags.py /app
 
-CMD ["sh", "-c", "python rl_loop/train_and_validate.py --bucket_name=$BUCKET_NAME"]
+CMD ["sh", "-c", "python rl_loop/train_and_validate.py --bucket_name=$BUCKET_NAME --pro_dataset=$PRO_DATASET"]

--- a/cluster/trainer/tpu-trainer-deployment.yaml
+++ b/cluster/trainer/tpu-trainer-deployment.yaml
@@ -31,6 +31,8 @@ spec:
           value: /etc/credentials/service-account.json
         - name: BUCKET_NAME
           value: $BUCKET_NAME
+        - name: PRO_DATASET
+          value: $PRO_DATASET
       volumes:
       - name: service-credentials
         secret:

--- a/rl_loop/distributed_flags
+++ b/rl_loop/distributed_flags
@@ -23,7 +23,6 @@
 --cbt_project=tensor-go
 --cbt_instance=minigo-instance
 --cbt_table=v14-games
---pro_dataset=gs://jacksona-sandbox/data/validate
 
 # Selfplay related flags.
 # These flags can be overwritten by --flags_path (see cc/main.cc for details)

--- a/rl_loop/distributed_flags
+++ b/rl_loop/distributed_flags
@@ -14,8 +14,8 @@
 --lr_rates=0.02
 --lr_rates=0.002
 --lr_rates=0.0005
---lr_boundaries=600000
---lr_boundaries=1000000
+--lr_boundaries=200000
+--lr_boundaries=800000
 --l2_strength=0.0001
 --sgd_momentum=0.95
 --steps_to_train=1024

--- a/rl_loop/train_and_validate.py
+++ b/rl_loop/train_and_validate.py
@@ -132,7 +132,7 @@ def validate_pro():
 
 def loop(unused_argv):
     while True:
-        print("=" * 40)
+        print("=" * 40, flush=True)
         with utils.timer("Train"):
             completed_process = train()
         if completed_process.returncode > 0:

--- a/rl_loop/train_and_validate.py
+++ b/rl_loop/train_and_validate.py
@@ -95,7 +95,7 @@ def freeze(save_path, rewrite_tpu=False):
            '--work_dir={}'.format(fsdb.working_dir()),
            '--model_path={}'.format(save_path)]
 
-    if use_tpu:
+    if rewrite_tpu:
         cmd.extend(['--use_tpu',
                     '--tpu_name={}'.format(TPU_NAME)])
 

--- a/train.py
+++ b/train.py
@@ -181,10 +181,12 @@ def train(*tf_records: "Records to train on"):
     if FLAGS.use_bt:
         games = bigtable_input.GameQueue(
             FLAGS.cbt_project, FLAGS.cbt_instance, FLAGS.cbt_table)
-        bigtable_input.set_fresh_watermark(games, FLAGS.window_size)
+        latest_game = games.latest_game_number
 
     try:
         estimator.train(_input_fn, steps=steps, hooks=hooks)
+        bigtable_input.set_fresh_watermark(games, latest_game,
+                                           FLAGS.window_size)
     except:
         if FLAGS.use_bt:
             games.require_fresh_games(0)

--- a/train.py
+++ b/train.py
@@ -177,13 +177,17 @@ def train(*tf_records: "Records to train on"):
     logging.info("Training, steps = %s, batch = %s -> %s examples",
                  steps or '?', effective_batch_size,
                  (steps * effective_batch_size) if steps else '?')
-    estimator.train(_input_fn, steps=steps, hooks=hooks)
 
     if FLAGS.use_bt:
         games = bigtable_input.GameQueue(
             FLAGS.cbt_project, FLAGS.cbt_instance, FLAGS.cbt_table)
         bigtable_input.set_fresh_watermark(games, FLAGS.window_size)
 
+    try:
+        estimator.train(_input_fn, steps=steps, hooks=hooks)
+    except:
+        if FLAGS.use_bt:
+            games.require_fresh_games(0)
 
 
 def main(argv):


### PR DESCRIPTION
Biggest fix is changing *when* we set the wait-cell -- we grab the index right before we start training, and then set the wait cell only *after* training is complete.

a few miscellaneous:
-refactor reading the WAIT_CELL into its own method
-a little more logging while waiting
-moved 'pro_dataset' back to an env var as it actually configures the behavior of the RL loop.