### PR TITLE
Fix tensorrt engine build

### DIFF
--- a/cc/BUILD
+++ b/cc/BUILD
@@ -87,6 +87,8 @@ cc_library(
     name = "tensorrt",
     tags = ["manual"],
     deps = [
+        "@local_config_cuda//:cuda_headers",
+        "@local_config_cuda//:cudart",
         "@local_config_tensorrt//:nv_infer",
         "@local_config_tensorrt//:nvparsers",
         "@local_config_tensorrt//:tensorrt_headers",

--- a/cc/dual_net/trt_dual_net.cc
+++ b/cc/dual_net/trt_dual_net.cc
@@ -132,7 +132,7 @@ class TrtDualNet : public DualNet {
 
  public:
   TrtDualNet(std::string graph_path, int device_count)
-      : graph_path_(std::move(graph_path)),
+      : graph_path_(graph_path),
         runtime_(nvinfer1::createInferRuntime(logger_)),
         parser_(nvuffparser::createUffParser()),
         batch_capacity_(0),
@@ -291,7 +291,7 @@ int TrtDualNetFactory::GetBufferCount() const { return device_count_ * 2; }
 
 std::unique_ptr<DualNet> TrtDualNetFactory::NewDualNet(
     const std::string& model) {
-  return absl::make_unique<TrtDualNet>(model);
+  return absl::make_unique<TrtDualNet>(model, device_count_);
 }
 
 }  // namespace minigo


### PR DESCRIPTION
I met some problems when I was building the minigo trt engine, then I did this fix and finally got the engine to work.

BTW: I also met the error of missing `cuda_runtime_api.h` and I fixed it by adding `"@local_config_cuda//:cuda_headers"` and `"@local_config_cuda//:cudart"` into the tensorrt part of the `BUILD` file, but I am not familiar with Bazel, so I don't know if that is the right way to fix, so I don't include that in the PR