### PR TITLE
[ml_perf]Better flags organization

### DIFF
--- a/ml_perf/flags/9/eval.flags
+++ b/ml_perf/flags/9/eval.flags
@@ -1,7 +1,7 @@
 # Flags for playing eval games.
 
 # Import the base selfplay flags.
---flagfile=ml_perf/flags/9/selfplay.flags
+--flagfile=ml_perf/flags/9/play.flags
 
 # Play fewer games for eval than selfplay.
 --parallel_games=100

--- a/ml_perf/flags/9/play.flags
+++ b/ml_perf/flags/9/play.flags
@@ -1,0 +1,10 @@
+# Flags for playing games.
+
+# This flagfile serves as the base for the boostrap & eval & selfplay stages of
+# the RL loop.
+
+--engine=tf
+--num_readouts=160
+--virtual_losses=8
+--value_init_penalty=2
+--resign_threshold=-0.99

--- a/ml_perf/flags/9/selfplay.flags
+++ b/ml_perf/flags/9/selfplay.flags
@@ -1,14 +1,7 @@
 # Flags for selfplay.
 
-# This flagfile also serves as the base for the boostrap & eval stages of
-# the RL loop.
-
---engine=tf
+--flagfile=ml_perf/flags/9/play.flags
 --num_games=2048
 --parallel_games=2048
---num_readouts=160
---virtual_losses=8
---value_init_penalty=2
 --holdout_pct=0.03
 --disable_resign_pct=0.1
---resign_threshold=-0.99

--- a/ml_perf/flags/9/topology.flags
+++ b/ml_perf/flags/9/topology.flags
@@ -1,0 +1,6 @@
+# Flags for model topology
+
+--conv_width=64
+--fc_width=64
+--trunk_layers=9
+--value_cost_weight=0.25

--- a/ml_perf/flags/9/train.flags
+++ b/ml_perf/flags/9/train.flags
@@ -1,8 +1,5 @@
-# Flags for training & validation.
+# Flags for training
 
---conv_width=64
---fc_width=64
---trunk_layers=9
---value_cost_weight=0.25
+--flagfile=ml_perf/flags/9/topology.flags
 --shuffle_buffer_size=10000
 --filter_amount=0.1

--- a/ml_perf/flags/9/validate.flags
+++ b/ml_perf/flags/9/validate.flags
@@ -1,0 +1,2 @@
+# Flags for validation.
+--flagfile=ml_perf/flags/9/topology.flags

--- a/ml_perf/reference_implementation.py
+++ b/ml_perf/reference_implementation.py
@@ -187,7 +187,7 @@ def train(state, tf_records):
 def validate(state, holdout_glob):
   checked_run('validation',
       'python3', 'validate.py', holdout_glob,
-      '--flagfile={}'.format(os.path.join(FLAGS.flags_dir, 'train.flags')),
+      '--flagfile={}'.format(os.path.join(FLAGS.flags_dir, 'validate.flags')),
       '--work_dir={}'.format(fsdb.working_dir()))
 
 


### PR DESCRIPTION
Move common parts of flags into separate files, and avoid same flags appear twice by inclusion.
* play.flags -- flags control the policy of play, used by both selfplay and evaluation
* topology.flags -- describe model topology
* Separate validation.flags for validation