### PR TITLE
Update flags for better convergence

### DIFF
--- a/ml_perf/eval_models.py
+++ b/ml_perf/eval_models.py
@@ -44,7 +44,7 @@ def main(unused_argv):
   models = load_train_times()
   for i, (timestamp, name) in enumerate(models):
     winrate = wait(evaluate_model(name, target, sgf_dir, i + 1))
-    if winrate > 0.55:
+    if winrate >= 0.50:
       break
 
 

--- a/ml_perf/flags/9/selfplay.flags
+++ b/ml_perf/flags/9/selfplay.flags
@@ -12,4 +12,4 @@
 
 # Device-specific selfplay flags.
 --parallel_games=2048
---virtual_losses=16
+--virtual_losses=8

--- a/ml_perf/flags/9/train.flags
+++ b/ml_perf/flags/9/train.flags
@@ -7,8 +7,9 @@
 
 # Device specific hyperparameters re: batch size and LR schedules.
 --train_batch_size=4096
---lr_rates=0.01
---lr_rates=0.002
+--lr_rates=0.16
+--lr_rates=0.016
+--lr_rates=0.0016
 --lr_boundaries=25000
---l2_strength=0.001
-
+--lr_boundaries=37500
+--l2_strength=0.0001


### PR DESCRIPTION
This set of hyper parameter make convergence better than the original by enlarge learning rate.
Changes:
1. Initial learning rate is 16x larger and l2_strength is set to 1e-4
2. Virtual loss is set to 8, just in case for reproducible, 16 should still work.
3. Target exit criteria is set to >=0.50, to make target easier to reach.