### PR TITLE
introduce multi-instance support to minigo cc

### DIFF
--- a/cc/eval.cc
+++ b/cc/eval.cc
@@ -68,6 +68,7 @@ DEFINE_string(model, "",
               "engine=lite, the model should be .tflite flatbuffer.");
 DEFINE_string(model_two, "", "Descriptor for the second model");
 DEFINE_int32(parallel_games, 32, "Number of games to play in parallel.");
+DEFINE_int32(instance_id, 0, "Unique id with multi-instance.");
 
 // Output flags.
 DEFINE_string(output_bigtable, "",
@@ -152,7 +153,10 @@ class Evaluator {
     ParseOptionsFromFlags(&game_options_, &player_options_);
 
     int num_games = FLAGS_parallel_games;
-    for (int thread_id = 0; thread_id < num_games; ++thread_id) {
+    int instance_id = FLAGS_instance_id;
+    int thread_id_begin = instance_id * num_games;
+    for (int thread_id = thread_id_begin;
+             thread_id < thread_id_begin + num_games; ++thread_id) {
       bool swap_models = (thread_id & 1) != 0;
       threads_.emplace_back(std::bind(&Evaluator::ThreadRun, this, thread_id,
                                       swap_models ? &model_b : &model_a,

--- a/cc/selfplay.cc
+++ b/cc/selfplay.cc
@@ -119,6 +119,7 @@ DEFINE_int32(parallel_games, 32, "Number of games to play in parallel.");
 DEFINE_int32(num_games, 0,
              "Total number of games to play. Defaults to parallel_games. "
              "Only one of num_games and run_forever must be set.");
+DEFINE_int32(instance_id, 0, "Unique id with multi-instance.");
 
 // Output flags.
 DEFINE_string(output_dir, "",
@@ -244,7 +245,10 @@ class SelfPlayer {
       batcher_ =
           absl::make_unique<BatchingDualNetFactory>(std::move(model_factory));
     }
-    for (int i = 0; i < FLAGS_parallel_games; ++i) {
+    int instance_id = FLAGS_instance_id;
+    int thread_id_begin = instance_id * FLAGS_parallel_games;
+    for (int i = thread_id_begin;
+             i < thread_id_begin + FLAGS_parallel_games; ++i) {
       threads_.emplace_back(std::bind(&SelfPlayer::ThreadRun, this, i));
     }
     for (auto& t : threads_) {


### PR DESCRIPTION
This code change add an instance_id parameter to selfplay.cc and eval.cc, to make sure multiple instance running on same host would generate unique play data filename.