### PR TITLE
Add Coral EdgeTPU compatibility. 

### DIFF
--- a/cc/mcts_player.h
+++ b/cc/mcts_player.h
@@ -129,8 +129,6 @@ class MctsPlayer {
 
   virtual void NewGame();
 
-  // If visitor is non-null, it is called on each batch of leaves visited during
-  // tree search.
   virtual Coord SuggestMove();
 
   // Plays the move at point c.

--- a/dual_net_edge_tpu.py
+++ b/dual_net_edge_tpu.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,42 +20,43 @@ compiled model file. For more information see https://coral.withgoogle.com
 
 import numpy as np
 import features as features_lib
+import go
 from edgetpu.basic.basic_engine import BasicEngine
 
-class DualNetworkEdgeTpu(object):
-  def __init__(self, save_file, board_size=19):
-    self.engine = BasicEngine(save_file)
-    self.board_size = board_size
-    self.output_policy_size = self.board_size**2 + 1
+class DualNetworkEdgeTpu():
+    def __init__(self, save_file):
+        self.engine = BasicEngine(save_file)
+        self.board_size = go.N
+        self.output_policy_size = self.board_size**2 + 1
 
-    input_tensor_shape = self.engine.get_input_tensor_shape()
-    expected_input_shape = [1,self.board_size,self.board_size,17]
-    if not np.array_equal(input_tensor_shape, expected_input_shape):
-      raise RuntimeError(
-          'Invalid input tensor shape {}. Expected: {}'.format(
-              input_tensor_shape, expected_input_shape))
-    output_tensors_sizes = self.engine.get_all_output_tensors_sizes()
-    expected_output_tensor_sizes = [self.output_policy_size, 1]
-    if not np.array_equal(output_tensors_sizes, expected_output_tensor_sizes):
-      raise RuntimeError(
-          'Invalid output tensor sizes {}. Expected: {}'.format(
-              output_tensors_sizes, expected_output_tensor_sizes))
+        input_tensor_shape = self.engine.get_input_tensor_shape()
+        expected_input_shape = [1, self.board_size, self.board_size, 17]
+        if not np.array_equal(input_tensor_shape, expected_input_shape):
+            raise RuntimeError(
+                    'Invalid input tensor shape {}. Expected: {}'.format(
+                            input_tensor_shape, expected_input_shape))
+        output_tensors_sizes = self.engine.get_all_output_tensors_sizes()
+        expected_output_tensor_sizes = [self.output_policy_size, 1]
+        if not np.array_equal(output_tensors_sizes, expected_output_tensor_sizes):
+            raise RuntimeError(
+                    'Invalid output tensor sizes {}. Expected: {}'.format(
+                            output_tensors_sizes, expected_output_tensor_sizes))
 
-  def run(self, position):
-    probs, values = self.run_many([position])
-    return probs[0], values[0]
+    def run(self, position):
+        probs, values = self.run_many([position])
+        return probs[0], values[0]
 
-  def run_many(self, positions):
-    processed = list(map(features_lib.extract_features, positions))
-    probabilities = []
-    values = []
-    for state in processed:
-      assert state.shape  == (self.board_size, self.board_size, 17), str(state.shape)
-      result = self.engine.RunInference(state.flatten())
-      inference_time = result[0] # ms
-      policy_output = result[1][0:self.output_policy_size]
-      value_output = result[1][-1]
-      probabilities.append(policy_output)
-      values.append(value_output)
-    return probabilities, values
-
+    def run_many(self, positions):
+        processed = list(map(features_lib.extract_features, positions))
+        probabilities = []
+        values = []
+        for state in processed:
+            assert state.shape == (self.board_size, self.board_size, 17), str(state.shape)
+            result = self.engine.RunInference(state.flatten())
+            # If needed you can get the raw inference time from the result object.
+            # inference_time = result[0] # ms
+            policy_output = result[1][0:self.output_policy_size]
+            value_output = result[1][-1]
+            probabilities.append(policy_output)
+            values.append(value_output)
+        return probabilities, values

--- a/dual_net_edge_tpu.py
+++ b/dual_net_edge_tpu.py
@@ -11,7 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""This file contains an implementation of dual_net.py for Google's EdgeTPU. It can only be used for inference and requires a specially quantized and compiled model file.
+"""This file contains an implementation of dual_net.py for Google's EdgeTPU.
+It can only be used for inference and requires a specially quantized and
+compiled model file.
 
 For more information see https://coral.withgoogle.com
 """
@@ -23,6 +25,7 @@ from edgetpu.basic.basic_engine import BasicEngine  # pylint: disable=import-err
 
 
 class DualNetworkEdgeTpu():
+    """DualNetwork implementation for Google's EdgeTPU."""
 
     def __init__(self, save_file):
         self.engine = BasicEngine(save_file)
@@ -44,10 +47,12 @@ class DualNetworkEdgeTpu():
                     output_tensors_sizes, expected_output_tensor_sizes))
 
     def run(self, position):
+        """Runs inference on a single position."""
         probs, values = self.run_many([position])
         return probs[0], values[0]
 
     def run_many(self, positions):
+        """Runs inference on a list of position."""
         processed = list(map(features_lib.extract_features, positions))
         probabilities = []
         values = []

--- a/dual_net_edge_tpu.py
+++ b/dual_net_edge_tpu.py
@@ -1,0 +1,61 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This file contains an implementation of dual_net.py for Google's EdgeTPU.
+It can only be used for inference and requires a specially quantized and
+compiled model file. For more information see https://coral.withgoogle.com
+"""
+
+import numpy as np
+import features as features_lib
+from edgetpu.basic.basic_engine import BasicEngine
+
+class DualNetworkEdgeTpu(object):
+  def __init__(self, save_file, board_size=19):
+    self.engine = BasicEngine(save_file)
+    self.board_size = board_size
+    self.output_policy_size = self.board_size**2 + 1
+
+    input_tensor_shape = self.engine.get_input_tensor_shape()
+    expected_input_shape = [1,self.board_size,self.board_size,17]
+    if not np.array_equal(input_tensor_shape, expected_input_shape):
+      raise RuntimeError(
+          'Invalid input tensor shape {}. Expected: {}'.format(
+              input_tensor_shape, expected_input_shape))
+    output_tensors_sizes = self.engine.get_all_output_tensors_sizes()
+    expected_output_tensor_sizes = [self.output_policy_size, 1]
+    if not np.array_equal(output_tensors_sizes, expected_output_tensor_sizes):
+      raise RuntimeError(
+          'Invalid output tensor sizes {}. Expected: {}'.format(
+              output_tensors_sizes, expected_output_tensor_sizes))
+
+  def run(self, position):
+    probs, values = self.run_many([position])
+    return probs[0], values[0]
+
+  def run_many(self, positions):
+    processed = list(map(features_lib.extract_features, positions))
+    probabilities = []
+    values = []
+    for state in processed:
+      assert state.shape  == (self.board_size, self.board_size, 17), str(state.shape)
+      result = self.engine.RunInference(state.flatten())
+      inference_time = result[0] # ms
+      policy_output = result[1][0:self.output_policy_size]
+      value_output = result[1][-1]
+      probabilities.append(policy_output)
+      values.append(value_output)
+    return probabilities, values
+

--- a/dual_net_edge_tpu.py
+++ b/dual_net_edge_tpu.py
@@ -11,19 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""This file contains an implementation of dual_net.py for Google's EdgeTPU. It can only be used for inference and requires a specially quantized and compiled model file.
 
-"""
-This file contains an implementation of dual_net.py for Google's EdgeTPU.
-It can only be used for inference and requires a specially quantized and
-compiled model file. For more information see https://coral.withgoogle.com
+For more information see https://coral.withgoogle.com
 """
 
 import numpy as np
 import features as features_lib
 import go
-from edgetpu.basic.basic_engine import BasicEngine
+from edgetpu.basic.basic_engine import BasicEngine  # pylint: disable=import-error
+
 
 class DualNetworkEdgeTpu():
+
     def __init__(self, save_file):
         self.engine = BasicEngine(save_file)
         self.board_size = go.N
@@ -33,14 +33,15 @@ class DualNetworkEdgeTpu():
         expected_input_shape = [1, self.board_size, self.board_size, 17]
         if not np.array_equal(input_tensor_shape, expected_input_shape):
             raise RuntimeError(
-                    'Invalid input tensor shape {}. Expected: {}'.format(
-                            input_tensor_shape, expected_input_shape))
+                'Invalid input tensor shape {}. Expected: {}'.format(
+                    input_tensor_shape, expected_input_shape))
         output_tensors_sizes = self.engine.get_all_output_tensors_sizes()
         expected_output_tensor_sizes = [self.output_policy_size, 1]
-        if not np.array_equal(output_tensors_sizes, expected_output_tensor_sizes):
+        if not np.array_equal(output_tensors_sizes,
+                              expected_output_tensor_sizes):
             raise RuntimeError(
-                    'Invalid output tensor sizes {}. Expected: {}'.format(
-                            output_tensors_sizes, expected_output_tensor_sizes))
+                'Invalid output tensor sizes {}. Expected: {}'.format(
+                    output_tensors_sizes, expected_output_tensor_sizes))
 
     def run(self, position):
         probs, values = self.run_many([position])
@@ -51,7 +52,8 @@ class DualNetworkEdgeTpu():
         probabilities = []
         values = []
         for state in processed:
-            assert state.shape == (self.board_size, self.board_size, 17), str(state.shape)
+            assert state.shape == (self.board_size, self.board_size,
+                                   17), str(state.shape)
             result = self.engine.RunInference(state.flatten())
             # If needed you can get the raw inference time from the result object.
             # inference_time = result[0] # ms

--- a/gtp.py
+++ b/gtp.py
@@ -45,6 +45,14 @@ def make_gtp_instance(load_file, cgos_mode=False, kgs_mode=False,
                       minigui_mode=False):
     """Takes a path to model files and set up a GTP engine instance."""
     n = DualNetwork(load_file)
+    # Here so we dont try load EdgeTPU python library unless we need to
+    if load_file.endswith(".tflite"):
+        from dual_net_edge_tpu import DualNetworkEdgeTpu
+        n = DualNetworkEdgeTpu(load_file)
+    else:
+        from dual_net import DualNetwork
+        n = DualNetwork(load_file)
+
     if cgos_mode:
         player = CGOSPlayer(network=n, seconds_per_move=5, timed_match=True,
                             two_player_mode=True)

--- a/gtp.py
+++ b/gtp.py
@@ -19,7 +19,6 @@ import sys
 
 from absl import app, flags
 
-from dual_net import DualNetwork
 from gtp_cmd_handlers import (
     BasicCmdHandler, KgsCmdHandler, GoGuiCmdHandler, MiniguiBasicCmdHandler, RegressionsCmdHandler)
 import gtp_engine
@@ -44,7 +43,6 @@ FLAGS = flags.FLAGS
 def make_gtp_instance(load_file, cgos_mode=False, kgs_mode=False,
                       minigui_mode=False):
     """Takes a path to model files and set up a GTP engine instance."""
-    n = DualNetwork(load_file)
     # Here so we dont try load EdgeTPU python library unless we need to
     if load_file.endswith(".tflite"):
         from dual_net_edge_tpu import DualNetworkEdgeTpu

--- a/minigui/control/minigo_edgetpu.ctl
+++ b/minigui/control/minigo_edgetpu.ctl
@@ -1,0 +1,14 @@
+board_size = 19
+
+players = {
+  "minigo_py" : Player("python"
+                       " -u"
+                       " gtp.py"
+                       " --load_file=models/minigo_20190107_edgetpu.tflite" 
+                       " --minigui_mode=true"
+                       " --num_readouts=128"
+                       " --resign_threshold=-0.8"
+                       " --verbose=2",
+                       startup_gtp_commands=[],
+                       environ={"BOARD_SIZE": str(board_size)}),
+}

--- a/minigui/edgetpu/install_requirements.sh
+++ b/minigui/edgetpu/install_requirements.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+python3 -m pip install -r minigui/requirements.txt
+
+# For Raspberry Pi
+if grep -q "Raspberry Pi" /sys/firmware/devicetree/base/model; then
+  sudo apt-get install chromium xautomation
+# For DevBoard
+elif grep -q "MX8MQ" /sys/firmware/devicetree/base/model; then
+  sudo apt-get install chromium xautomation
+else
+  echo "Generic Linux system"
+fi
+
+cat << EOF | python3
+try: import edgetpu
+except ImportError: 
+  print("\nNo EdgeTPU libs found.")
+  print("Follow instructions at https://coral.withgoogle.com/tutorials/accelerator/ to install the EdgeTPU")
+EOF
+

--- a/minigui/edgetpu/start_chromium_kiosk.sh
+++ b/minigui/edgetpu/start_chromium_kiosk.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+killall chromium
+export DISPLAY=:0
+export GDK_BACKEND=x11
+chromium --incognito http://localhost:5001/kiosk.html &
+CHROMIUM_PID=$!
+sleep 5
+xte -x :0 "key F11"
+xte -x :0 "keydown Control_L" "key 0" "keyup Control_L"
+wait ${CHROMIUM_PID}

--- a/minigui/requirements.txt
+++ b/minigui/requirements.txt
@@ -1,2 +1,4 @@
+absl-py
+numpy
 flask
 flask-socketio


### PR DESCRIPTION
Adapt minigo python engine to use EdgeTPU by adding a custom dual_net.py

This supports both the EdgeTPU dev board and the USB form factor for
Linux and Raspberry Pi hosts. In order not to use dependencies that
aren't present or available on all plattforms the imports are inside
the if statement. Potentially this could be moved to it's own
dual_net_chooser.py or something.

Also added some convenience scripts in minigui/edgetpu
