### PR TITLE
Adds "target pruning" for greater policy concentration & extra shine.

### DIFF
--- a/cc/mcts_node.cc
+++ b/cc/mcts_node.cc
@@ -142,14 +142,17 @@ void MctsNode::ReshapeFinalVisits() {
       continue;
     }
 
-    int new_N = std::max(0, std::min(int(child_N(i)),
-                         int(std::floor(-1 * (U_scale() * child_P(i) * std::sqrt(N())) /
-                         ( (child_Q(i) * to_play) - best_cas)) - 1 )));
+    // Change N_child to the smallest value that satisfies the inequality
+    // best_cas > Q + (U_scale * P * sqrt(N_parent) / N_child)
+    // Solving for N_child, we get:
+    int new_N = std::max(0, std::min(static_cast<int>(child_N(i)),
+        static_cast<int>(-1 * (U_scale() * child_P(i) * std::sqrt(N())) /
+        ((child_Q(i) * to_play) - best_cas)) - 1 ));
     total += edges[i].N - new_N;
     edges[i].N = new_N;
-  }
 
-  MG_LOG(INFO) << "Pruned " << total << " visits.";
+  }
+  MG_LOG(DEBUG) << "Pruned " << total << " visits.";
 }
 
 

--- a/cc/mcts_node.cc
+++ b/cc/mcts_node.cc
@@ -140,19 +140,33 @@ void MctsNode::ReshapeFinalVisits() {
   MG_LOG(INFO) << "Best CAS: " << best_cas;
   MG_LOG(INFO) << "Post_prune: ";
   int total = 0;
-  float Q;
+  //float Q;
   for (int i = 0; i < kNumMoves; ++i) {
     // Store Q before modifications, as child_Q depends on edges[i].N.
+    if (i == uint16_t(best)){
+      continue;
+    }
+    /*
     Q = child_Q(i);
     while ((Q * to_play + child_U(i) < best_cas) &&
-           (edges[i].N > 0)) {
+                             (edges[i].N > 0)) {
       edges[i].N --;
       total++;
     }
+    */
+
+    // Closed form doesn't work :(
+    int new_N = std::max(0, std::min(int(child_N(i)),
+                         int(std::floor(-1 * (U_scale() * child_P(i) * std::sqrt(N())) / 
+                         ( (child_Q(i) * to_play) - best_cas)) - 1 )));
+    // MG_LOG(INFO) << i << ": " << new_N << " was: " << edges[i].N;
+    total += edges[i].N - new_N;
+    edges[i].N = new_N;
   }
 
-  MG_LOG(INFO) << "Pruned " << total << " visits.";
   MG_LOG(INFO) << Describe();
+
+  MG_LOG(INFO) << "Pruned " << total << " visits.";
 }
 
 

--- a/cc/mcts_node.cc
+++ b/cc/mcts_node.cc
@@ -136,7 +136,7 @@ void MctsNode::ReshapeFinalVisits() {
   float best_cas =
       CalculateSingleMoveChildActionScore(to_play, U_common, uint16_t(best));
 
-  int total = 0;
+  //int total = 0;
   for (int i = 0; i < kNumMoves; ++i) {
     if (i == uint16_t(best)) {
       continue;
@@ -148,11 +148,10 @@ void MctsNode::ReshapeFinalVisits() {
     int new_N = std::max(0, std::min(static_cast<int>(child_N(i)),
         static_cast<int>(-1 * (U_scale() * child_P(i) * std::sqrt(N())) /
         ((child_Q(i) * to_play) - best_cas)) - 1 ));
-    total += edges[i].N - new_N;
+    //total += edges[i].N - new_N;
     edges[i].N = new_N;
-
   }
-  MG_LOG(DEBUG) << "Pruned " << total << " visits.";
+  //MG_LOG(DEBUG) << "Pruned " << total << " visits.";
 }
 
 

--- a/cc/mcts_node.cc
+++ b/cc/mcts_node.cc
@@ -151,7 +151,7 @@ void MctsNode::ReshapeFinalVisits() {
     //total += edges[i].N - new_N;
     edges[i].N = new_N;
   }
-  //MG_LOG(DEBUG) << "Pruned " << total << " visits.";
+  //MG_LOG(INFO) << "Pruned " << total << " visits.";
 }
 
 

--- a/cc/mcts_node.cc
+++ b/cc/mcts_node.cc
@@ -136,35 +136,18 @@ void MctsNode::ReshapeFinalVisits() {
   float best_cas =
       CalculateSingleMoveChildActionScore(to_play, U_common, uint16_t(best));
 
-  MG_LOG(INFO) << "=================================";
-  MG_LOG(INFO) << "Best CAS: " << best_cas;
-  MG_LOG(INFO) << "Post_prune: ";
   int total = 0;
-  //float Q;
   for (int i = 0; i < kNumMoves; ++i) {
-    // Store Q before modifications, as child_Q depends on edges[i].N.
-    if (i == uint16_t(best)){
+    if (i == uint16_t(best)) {
       continue;
     }
-    /*
-    Q = child_Q(i);
-    while ((Q * to_play + child_U(i) < best_cas) &&
-                             (edges[i].N > 0)) {
-      edges[i].N --;
-      total++;
-    }
-    */
 
-    // Closed form doesn't work :(
     int new_N = std::max(0, std::min(int(child_N(i)),
-                         int(std::floor(-1 * (U_scale() * child_P(i) * std::sqrt(N())) / 
+                         int(std::floor(-1 * (U_scale() * child_P(i) * std::sqrt(N())) /
                          ( (child_Q(i) * to_play) - best_cas)) - 1 )));
-    // MG_LOG(INFO) << i << ": " << new_N << " was: " << edges[i].N;
     total += edges[i].N - new_N;
     edges[i].N = new_N;
   }
-
-  MG_LOG(INFO) << Describe();
 
   MG_LOG(INFO) << "Pruned " << total << " visits.";
 }

--- a/cc/mcts_node.h
+++ b/cc/mcts_node.h
@@ -54,6 +54,7 @@ class MctsNode {
   struct ChildInfo {
     Coord c = Coord::kInvalid;
     float N;
+    float P;
     float action_score;
   };
 
@@ -148,6 +149,9 @@ class MctsNode {
 
   // Remove all children from the node except c.
   void PruneChildren(Coord c);
+
+  // Adjust the visit counts via whatever hairbrained scheme.
+  void ReshapeFinalVisits();
 
   std::array<float, kNumMoves> CalculateChildActionScore() const;
 

--- a/cc/mcts_node.h
+++ b/cc/mcts_node.h
@@ -162,6 +162,7 @@ class MctsNode {
     return Q * to_play + U - 1000.0f * !position.legal_move(i);
   }
 
+
   MctsNode* MaybeAddChild(Coord c);
 
   // Calculate and print statistics about the tree.

--- a/cc/mcts_node_test.cc
+++ b/cc/mcts_node_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "cc/mcts_node.h"
+#include <sys/types.h>
 
 #include <array>
 #include <set>
@@ -427,6 +428,96 @@ TEST(MctsNodeTest, TestSelectLeaf) {
   // We should have selected at least 2 leaves.
   EXPECT_LE(2, leaves.size());
 }
+
+class ReshapeTargetTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    best_ = -1;
+  }
+
+  void SearchTestablePosition(
+      TestablePosition p) {
+    float to_play = p.to_play() == Color::kBlack ? 1 : -1;
+
+    std::array<float, kNumMoves> probs;
+    for (float& prob : probs) {
+      prob = 0.001;
+    }
+    probs[17] = 0.99;
+
+    MctsNode::EdgeStats root_stats;
+    root_ = new MctsNode(&root_stats, p);
+    root_->SelectLeaf()->IncorporateResults(0.0, probs, 0, root_);
+
+    MctsNode* leaf;
+    for (int i = 0; i < 10000; ++i) {
+      leaf = root_->SelectLeaf();
+      if (leaf->move == 17) {
+        leaf->BackupValue(0.0, root_);
+      } else {
+        leaf->BackupValue(to_play * -0.10, root_);
+      }
+    }
+
+    pre_scores_ = root_->CalculateChildActionScore();
+
+    std::array<float, kNumMoves> saved_Q;
+    for (int i = 0; i < kNumMoves; ++i) {
+      saved_Q[i] = root_->child_Q(i);
+    }
+    best_ = root_->GetMostVisitedMove();
+    root_->ReshapeFinalVisits();
+
+    float U_common = root_->U_scale() * std::sqrt(std::max<float>(1, root_->N() - 1));
+
+    for (int i = 0; i < kNumMoves; ++i) {
+      post_scores_[i] = (saved_Q[i] * to_play +
+                         (U_common * root_->child_P(i) / (1 + root_->child_N(i))));
+      post_scores_[i] -= 1000.0f * !p.legal_move(i);
+    }
+  }
+
+  std::array<float, kNumMoves> post_scores_;
+  std::array<float, kNumMoves> pre_scores_;
+  uint16_t best_;
+  MctsNode* root_;
+};
+
+
+TEST_F(ReshapeTargetTest, TestReshapeTargetsWhite) {
+  auto board = TestablePosition("", Color::kWhite);
+  SearchTestablePosition(TestablePosition("", Color::kWhite));
+  int tot_N = 0;
+
+  // Scores should never get smaller as a result of visits being deducted.
+  for (int i = 0; i < kNumMoves; i++) {
+    EXPECT_LE(pre_scores_[i], post_scores_[i]);
+    tot_N += root_->child_N(i);
+  }
+  // Score for original best move should be the same.
+  EXPECT_EQ(pre_scores_[best_], post_scores_[best_]);
+  // Root visits is now greater than sum(child visits)
+  EXPECT_LT(tot_N, root_->N());
+  // For the default cpuct params, this should only trim ~1% of reads.
+  // If we trimmed over 10%, something is probably wrong.
+  EXPECT_GT(tot_N, root_->N() * 0.90);
+}
+
+
+// As above
+TEST_F(ReshapeTargetTest, TestReshapeTargetsBlack) {
+  auto board = TestablePosition("", Color::kBlack);
+  SearchTestablePosition(TestablePosition("", Color::kBlack));
+  int tot_N = 0;
+  for (int i = 0; i < kNumMoves; i++) {
+    EXPECT_LE(pre_scores_[i], post_scores_[i]);
+    tot_N += root_->child_N(i);
+  }
+  EXPECT_EQ(pre_scores_[best_], post_scores_[best_]);
+  EXPECT_LT(tot_N, root_->N());
+  EXPECT_GT(tot_N, root_->N() * 0.90);
+}
+
 
 TEST(MctsNodeTest, NormalizeTest) {
   // Generate probability with sum of policy less than 1

--- a/cc/mcts_player.cc
+++ b/cc/mcts_player.cc
@@ -159,11 +159,15 @@ Coord MctsPlayer::SuggestMove(int new_readouts, bool inject_noise) {
     return Coord::kResign;
   }
 
+  auto c = PickMove();
+
+  // After picking the move, destructively adjust the visit counts
+  // according to whatever flag-controlled scheme.
   if (options_.target_pruning && inject_noise) {
     root_->ReshapeFinalVisits();
   }
 
-  return PickMove();
+  return c;
 }
 
 Coord MctsPlayer::PickMove() {
@@ -334,6 +338,8 @@ void MctsPlayer::UpdateGame(Coord c) {
     }
     std::reverse(models.begin(), models.end());
   }
+
+  // Reshape the targets if needed.
 
   // Build a comment for the move.
   auto comment = root_->Describe();

--- a/cc/mcts_player.cc
+++ b/cc/mcts_player.cc
@@ -15,6 +15,7 @@
 #include "cc/mcts_player.h"
 
 #include <algorithm>
+#include <cstdlib>
 #include <sstream>
 #include <utility>
 
@@ -42,6 +43,7 @@ std::ostream& operator<<(std::ostream& os, const MctsPlayer::Options& options) {
      << " decay_factor:" << options.decay_factor
      << " fastplay_frequency:" << options.fastplay_frequency
      << " fastplay_readouts:" << options.fastplay_readouts
+     << " target_pruning:" << options.target_pruning
      << " random_seed:" << options.random_seed << std::flush;
   return os;
 }
@@ -155,6 +157,10 @@ Coord MctsPlayer::SuggestMove(int new_readouts, bool inject_noise) {
   }
   if (ShouldResign()) {
     return Coord::kResign;
+  }
+
+  if (options_.target_pruning && inject_noise) {
+    root_->ReshapeFinalVisits();
   }
 
   return PickMove();

--- a/cc/mcts_player.cc
+++ b/cc/mcts_player.cc
@@ -159,6 +159,7 @@ Coord MctsPlayer::SuggestMove(int new_readouts, bool inject_noise) {
     return Coord::kResign;
   }
 
+  // Pick the move before altering the tree for training targets.
   auto c = PickMove();
 
   // After picking the move, destructively adjust the visit counts

--- a/cc/mcts_player.cc
+++ b/cc/mcts_player.cc
@@ -340,8 +340,6 @@ void MctsPlayer::UpdateGame(Coord c) {
     std::reverse(models.begin(), models.end());
   }
 
-  // Reshape the targets if needed.
-
   // Build a comment for the move.
   auto comment = root_->Describe();
   if (!models.empty()) {

--- a/cc/mcts_player.h
+++ b/cc/mcts_player.h
@@ -109,6 +109,10 @@ class MctsPlayer {
     float fastplay_frequency = 0;
     int fastplay_readouts = 20;
 
+    // Adjust the targets after reading to discard reads caused by 'unhelpful'
+    // noise.
+    bool target_pruning = false;
+
     friend std::ostream& operator<<(std::ostream& ios, const Options& options);
   };
 

--- a/cc/selfplay.cc
+++ b/cc/selfplay.cc
@@ -105,6 +105,10 @@ DEFINE_int32(fastplay_readouts, 20,
              "aka 'playout cap oscillation'.\nIf this is set, "
              "'fastplay_frequency' should be nonzero.");
 
+DEFINE_bool(target_pruning, false,
+            "If true, subtract visits from all moves that weren't the best move "
+            "until the uncertainty level compensates.");
+
 // Time control flags.
 DEFINE_double(seconds_per_move, 0,
               "If non-zero, the number of seconds to spend thinking about each "
@@ -173,6 +177,7 @@ void ParseOptionsFromFlags(Game::Options* game_options,
   player_options->decay_factor = FLAGS_decay_factor;
   player_options->fastplay_frequency = FLAGS_fastplay_frequency;
   player_options->fastplay_readouts = FLAGS_fastplay_readouts;
+  player_options->target_pruning = FLAGS_target_pruning;
 }
 
 void LogEndGameInfo(const Game& game, absl::Duration game_time) {


### PR DESCRIPTION
not yet ready for review, needs tests.

@brilee the generic 'reshape visit counts' would be a good place to consolidate the temperature squash/stretch logic, as well as any other hairbrained schemes, encapsulated behind nice flags.  What do you think?