### PR TITLE
Updated MLPerf implementation

### DIFF
--- a/cc/BUILD
+++ b/cc/BUILD
@@ -68,7 +68,6 @@ minigo_cc_library(
         "//cc/platform",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
-        "@com_google_absl//absl/time",
     ],
 )
 

--- a/cc/dual_net/BUILD
+++ b/cc/dual_net/BUILD
@@ -95,6 +95,8 @@ minigo_cc_library(
         "//cc:logging",
         "//cc:random",
         "//cc/model",
+        "//cc/model:buffered_model",
+        "//cc/platform",
         "@com_google_absl//absl/memory",
     ],
 )

--- a/cc/dual_net/dual_net_test.cc
+++ b/cc/dual_net/dual_net_test.cc
@@ -149,7 +149,7 @@ TEST(DualNetTest, TestBackendsEqual) {
 
 #if MG_ENABLE_TF_DUAL_NET
   tests.emplace("TfDualNet",
-                Test(absl::make_unique<TfDualNetFactory>(), "test_model.pb"));
+                Test(absl::make_unique<TfDualNetFactory>(std::vector<int>()), "test_model.pb"));
 #endif
 #if MG_ENABLE_LITE_DUAL_NET
   tests.emplace("LiteDualNet", Test(absl::make_unique<LiteDualNetFactory>(),

--- a/cc/dual_net/factory.cc
+++ b/cc/dual_net/factory.cc
@@ -76,8 +76,16 @@ std::unique_ptr<ModelFactory> NewModelFactory(absl::string_view engine_desc) {
 
 #ifdef MG_ENABLE_TF_DUAL_NET
   if (engine == "tf") {
-    MG_CHECK(arg_str.empty());
-    return absl::make_unique<TfDualNetFactory>();
+    std::vector<int> devices;
+    if (!arg_str.empty()) {
+      std::vector<std::string> args = absl::StrSplit(arg_str, ":");
+      for (const auto& arg : args) {
+        int device;
+        MG_CHECK(absl::SimpleAtoi(arg, &device)) << "\"" << arg << "\"";
+        devices.push_back(device);
+      }
+    }
+    return absl::make_unique<TfDualNetFactory>(devices);
   }
 #endif  // MG_ENABLE_TF_DUAL_NET
 

--- a/cc/dual_net/tf_dual_net.h
+++ b/cc/dual_net/tf_dual_net.h
@@ -25,12 +25,12 @@ namespace minigo {
 
 class TfDualNetFactory : public ModelFactory {
  public:
-  TfDualNetFactory();
+  explicit TfDualNetFactory(std::vector<int> devices);
 
   std::unique_ptr<Model> NewModel(const std::string& descriptor) override;
 
  private:
-  int device_count_ = 0;
+  std::vector<int> devices_;
 };
 
 }  // namespace minigo

--- a/cc/dual_net/tpu_dual_net.cc
+++ b/cc/dual_net/tpu_dual_net.cc
@@ -242,7 +242,7 @@ std::unique_ptr<Model> TpuDualNetFactory::NewModel(
                                                    graph_def, num_replicas));
   }
 
-  return absl::make_unique<BufferedModel>(descriptor, std::move(models));
+  return absl::make_unique<BufferedModel>(std::move(models));
 }
 
 }  // namespace minigo

--- a/cc/game_utils.cc
+++ b/cc/game_utils.cc
@@ -61,9 +61,8 @@ std::string FormatWinStatsTable(
   return result;
 }
 
-std::string GetOutputName(absl::Time now, size_t game_id) {
-  return absl::StrCat(absl::ToUnixSeconds(now), "-", GetHostname(), "-",
-                      GetProcessId(), "-", game_id);
+std::string GetOutputName(size_t game_id) {
+  return absl::StrCat(GetHostname(), "-", GetProcessId(), "-", game_id);
 }
 
 void WriteSgf(const std::string& output_dir, const std::string& output_name,

--- a/cc/game_utils.h
+++ b/cc/game_utils.h
@@ -20,7 +20,6 @@
 #include <utility>
 #include <vector>
 
-#include "absl/time/time.h"
 #include "cc/game.h"
 
 namespace minigo {
@@ -62,9 +61,8 @@ std::string FormatWinStatsTable(
     const std::vector<std::pair<std::string, WinStats>>& stats);
 
 // Returns the name (specifically the basename stem) for an output game file
-// (e.g. SGF, TF example, etc) based on the current time, hostname, process ID
-// and game ID.
-std::string GetOutputName(absl::Time now, size_t game_id);
+// (e.g. SGF, TF example, etc) based on the hostname, process ID and game ID.
+std::string GetOutputName(size_t game_id);
 
 // Writes an SGF of the given game.
 void WriteSgf(const std::string& output_dir, const std::string& output_name,

--- a/cc/mcts_node.cc
+++ b/cc/mcts_node.cc
@@ -312,7 +312,7 @@ void MctsNode::InjectNoise(const std::array<float, kNumMoves>& noise,
   }
 }
 
-MctsNode* MctsNode::SelectLeaf(bool allow_pass) {
+MctsNode* MctsNode::SelectLeaf() {
   auto* node = this;
   for (;;) {
     // If a node has never been evaluated, we have no basis to select a child.
@@ -327,16 +327,7 @@ MctsNode* MctsNode::SelectLeaf(bool allow_pass) {
     }
 
     auto child_action_score = node->CalculateChildActionScore();
-    Coord best_move;
-
-
-    best_move = ArgMax(child_action_score);
-    if (allow_pass) {
-      best_move = ArgMax(child_action_score);
-    } else {
-      best_move = ArgMax(absl::MakeSpan(child_action_score.data(), kN * kN));
-    }
-
+    auto best_move = ArgMax(child_action_score);
     if (!node->position.legal_move(best_move)) {
       best_move = Coord::kPass;
     }

--- a/cc/mcts_node.h
+++ b/cc/mcts_node.h
@@ -131,7 +131,7 @@ class MctsNode {
   // If inference is being batched and SelectLeaf chooses a node that has
   // already been added to the batch (IncorporateResults has not yet been
   // called), then SelectLeaf will return that same node.
-  MctsNode* SelectLeaf(bool allow_pass);
+  MctsNode* SelectLeaf();
 
   void IncorporateResults(float value_init_penalty,
                           absl::Span<const float> move_probabilities,

--- a/cc/mcts_node.h
+++ b/cc/mcts_node.h
@@ -131,7 +131,7 @@ class MctsNode {
   // If inference is being batched and SelectLeaf chooses a node that has
   // already been added to the batch (IncorporateResults has not yet been
   // called), then SelectLeaf will return that same node.
-  MctsNode* SelectLeaf();
+  MctsNode* SelectLeaf(bool allow_pass);
 
   void IncorporateResults(float value_init_penalty,
                           absl::Span<const float> move_probabilities,

--- a/cc/mcts_player.cc
+++ b/cc/mcts_player.cc
@@ -212,9 +212,8 @@ void MctsPlayer::SelectLeaves(int num_leaves) {
   int num_selected = 0;
   int num_cache_misses = 0;
   int num_cache_hits = 0;
-  bool allow_pass_reads = options_.allow_pass;// && (root_->position.n() >= temperature_cutoff_);
   while (num_cache_misses < max_cache_misses) {
-    auto* leaf = root_->SelectLeaf(allow_pass_reads);
+    auto* leaf = root_->SelectLeaf();
 
     if (leaf->game_over() || leaf->at_move_limit()) {
       float value =

--- a/cc/mcts_player.cc
+++ b/cc/mcts_player.cc
@@ -212,8 +212,9 @@ void MctsPlayer::SelectLeaves(int num_leaves) {
   int num_selected = 0;
   int num_cache_misses = 0;
   int num_cache_hits = 0;
+  bool allow_pass_reads = options_.allow_pass;// && (root_->position.n() >= temperature_cutoff_);
   while (num_cache_misses < max_cache_misses) {
-    auto* leaf = root_->SelectLeaf();
+    auto* leaf = root_->SelectLeaf(allow_pass_reads);
 
     if (leaf->game_over() || leaf->at_move_limit()) {
       float value =

--- a/cc/mcts_player.h
+++ b/cc/mcts_player.h
@@ -58,9 +58,8 @@ class MctsPlayer {
 
     int virtual_losses = 8;
 
-    // Seed used from random permutations.
-    // If the default value of 0 is used, a time-based seed is chosen.
-    uint64_t random_seed = 0;
+    // Random seed & stream used for random permutations.
+    uint64_t random_seed = Random::kUniqueSeed;
 
     // If true, flip & rotate the board features when performing inference. The
     // symmetry chosen is psuedo-randomly chosen in a deterministic way based
@@ -117,6 +116,8 @@ class MctsPlayer {
     // caused by 'unhelpful' noise & reflect the 'better' understanding of the
     // reward distribution.  "False" == no pruning will be applied.
     bool target_pruning = false;
+
+    bool allow_pass = true;
 
     friend std::ostream& operator<<(std::ostream& ios, const Options& options);
   };

--- a/cc/mcts_player.h
+++ b/cc/mcts_player.h
@@ -117,8 +117,6 @@ class MctsPlayer {
     // reward distribution.  "False" == no pruning will be applied.
     bool target_pruning = false;
 
-    bool allow_pass = true;
-
     friend std::ostream& operator<<(std::ostream& ios, const Options& options);
   };
 

--- a/cc/model/buffered_model.cc
+++ b/cc/model/buffered_model.cc
@@ -16,9 +16,8 @@
 
 namespace minigo {
 
-BufferedModel::BufferedModel(std::string name,
-                             std::vector<std::unique_ptr<Model>> impls)
-    : Model(std::move(name), static_cast<int>(impls.size())) {
+BufferedModel::BufferedModel(std::vector<std::unique_ptr<Model>> impls)
+    : Model(impls[0]->name(), static_cast<int>(impls.size())) {
   for (auto& x : impls) {
     impls_.Push(std::move(x));
   }

--- a/cc/model/buffered_model.h
+++ b/cc/model/buffered_model.h
@@ -26,16 +26,13 @@ namespace minigo {
 
 class BufferedModel : public Model {
  public:
-  BufferedModel(std::string name, std::vector<std::unique_ptr<Model>> impls);
-
-  const std::string& name() const { return name_; }
+  explicit BufferedModel(std::vector<std::unique_ptr<Model>> impls);
 
   void RunMany(const std::vector<const Input*>& inputs,
                std::vector<Output*>* outputs, std::string* model_name) override;
 
  private:
   ThreadSafeQueue<std::unique_ptr<Model>> impls_;
-  const std::string name_;
 };
 
 }  // namespace minigo

--- a/cc/model/reloading_model.cc
+++ b/cc/model/reloading_model.cc
@@ -179,7 +179,6 @@ void ReloadingModel::UpdateImpl(std::unique_ptr<Model> model_impl) {
 ReloadingModelFactory::ReloadingModelFactory(std::unique_ptr<ModelFactory> impl,
                                              absl::Duration poll_interval)
     : factory_impl_(std::move(impl)), poll_interval_(poll_interval) {
-  running_ = true;
   thread_ = std::thread(&ReloadingModelFactory::ThreadRun, this);
 }
 

--- a/cc/model/reloading_model.h
+++ b/cc/model/reloading_model.h
@@ -81,7 +81,7 @@ class ReloadingModelFactory : public ModelFactory {
   absl::flat_hash_map<std::string, std::unique_ptr<ReloadingModelUpdater>>
       updaters_ GUARDED_BY(&mutex_);
 
-  std::atomic<bool> running_;
+  std::atomic<bool> running_{true};
   std::unique_ptr<ModelFactory> factory_impl_;
   const absl::Duration poll_interval_;
   std::thread thread_;

--- a/cc/selfplay.cc
+++ b/cc/selfplay.cc
@@ -61,7 +61,6 @@ DEFINE_uint64(seed, 0,
               "game has resignation disabled or is a holdout.");
 DEFINE_double(holdout_pct, 0.03,
               "Fraction of games to hold out for validation.");
-DEFINE_bool(allow_pass, true, "");
 
 // Tree search flags.
 DEFINE_int32(num_readouts, 100,
@@ -187,7 +186,6 @@ void ParseOptionsFromFlags(Game::Options* game_options,
   player_options->fastplay_frequency = FLAGS_fastplay_frequency;
   player_options->fastplay_readouts = FLAGS_fastplay_readouts;
   player_options->target_pruning = FLAGS_target_pruning;
-  player_options->allow_pass = FLAGS_allow_pass;
 }
 
 void LogEndGameInfo(const Game& game, absl::Duration game_time) {

--- a/dual_net.py
+++ b/dual_net.py
@@ -97,6 +97,9 @@ flags.DEFINE_integer(
     help=('Number of TPU cores. For a single TPU device, this is 8 because each'
           ' TPU has 4 chips each with 2 cores.'))
 
+flags.DEFINE_string('gpu_device_list', None,
+                    'Comma-separated list of GPU device IDs to use.')
+
 flags.DEFINE_bool('quantize', False,
                   'Whether create a quantized model. When loading a model for '
                   'inference, this must match how the model was trained.')
@@ -159,6 +162,8 @@ class DualNetwork():
         self.inference_output = None
         config = tf.ConfigProto()
         config.gpu_options.allow_growth = True
+        if FLAGS.gpu_device_list is not None:
+            config.gpu_options.visible_device_list = FLAGS.gpu_device_list
         self.sess = tf.Session(graph=tf.Graph(), config=config)
         self.initialize_graph()
 

--- a/ml_perf/README.md
+++ b/ml_perf/README.md
@@ -46,7 +46,7 @@ commands. This may vary on a different operating system or graphics card.
     ./cc/configure_tensorflow.sh
 
     # Compile and run C++ self-play and evaluation binaries
-    bazel build  -c opt  --define=tf=1  --define=board_size=9  cc:selfplay  cc:eval
+    bazel build  -c opt  --define=tf=1  --define=board_size=9  cc:sample_records  cc:selfplay  cc:eval
 
     # Download required files from Google Cloud Storage
     BOARD_SIZE=9 python ml_perf/get_data.py

--- a/ml_perf/eval_models.py
+++ b/ml_perf/eval_models.py
@@ -33,8 +33,8 @@ def load_train_times():
       line = line.strip()
       if line:
         timestamp, name = line.split(' ')
-        models.append((float(timestamp), 
-            'tf,' + os.path.join(fsdb.models_dir(), name + '.pb')))
+        path = 'tf,' + os.path.join(fsdb.models_dir(), name + '.pb')
+        models.append((float(timestamp), name, path))
   return models
 
 
@@ -42,8 +42,8 @@ def main(unused_argv):
   sgf_dir = os.path.join(fsdb.eval_dir(), 'target')
   target = 'tf,' + os.path.join(fsdb.models_dir(), 'target.pb')
   models = load_train_times()
-  for i, (timestamp, name) in enumerate(models):
-    winrate = wait(evaluate_model(name, target, sgf_dir, i + 1))
+  for i, (timestamp, name, path) in enumerate(models):
+    winrate = wait(evaluate_model(path, name, target, sgf_dir))
     if winrate >= 0.50:
       break
 

--- a/ml_perf/flags/9/architecture.flags
+++ b/ml_perf/flags/9/architecture.flags
@@ -3,5 +3,5 @@
 --conv_width=32
 --fc_width=64
 --trunk_layers=9
---value_cost_weight=1
+--value_cost_weight=0.5
 --summary_steps=64

--- a/ml_perf/flags/9/bootstrap.flags
+++ b/ml_perf/flags/9/bootstrap.flags
@@ -3,8 +3,6 @@
 
 --flagfile=ml_perf/flags/9/selfplay.flags
 
-# Don't perform holdout for the first bootstrap round.
 --holdout_pct=0
-
---num_games=8192
---num_readouts=20
+# --parallel_games=16
+# --allow_pass=false

--- a/ml_perf/flags/9/eval.flags
+++ b/ml_perf/flags/9/eval.flags
@@ -2,6 +2,6 @@
 
 --flagfile=ml_perf/flags/9/selfplay.flags
 
-# Play fewer games for eval than selfplay.
---num_games=100
---parallel_games=100
+# --num_readouts=240
+--fastplay_frequency=0
+--resign_enabled=false

--- a/ml_perf/flags/9/rl_loop.flags
+++ b/ml_perf/flags/9/rl_loop.flags
@@ -1,5 +1,3 @@
-# rl_loop.flags: Flags for the reinforcement learning loop.
-
 --flags_dir=ml_perf/flags/9/
 --checkpoint_dir=ml_perf/checkpoint/9/
 
@@ -7,4 +5,14 @@
 --gating_win_rate=0.49
 --window_size=10
 --engine=tf
---parallel_post_train=true
+
+--train_devices=0
+--eval_devices=0
+--selfplay_devices=1,2,3,4,5,6,7
+
+--bootstrap_target_win_rate=0.05
+
+--bootstrap_num_models=8
+--selfplay_num_games=4096
+--selfplay_num_games_per_thread=3
+--eval_num_games=100

--- a/ml_perf/flags/9/rl_loop.flags
+++ b/ml_perf/flags/9/rl_loop.flags
@@ -13,6 +13,6 @@
 --bootstrap_target_win_rate=0.05
 
 --bootstrap_num_models=8
---selfplay_num_games=4096
+--selfplay_num_games=8192
 --selfplay_num_games_per_thread=3
 --eval_num_games=100

--- a/ml_perf/flags/9/selfplay.flags
+++ b/ml_perf/flags/9/selfplay.flags
@@ -3,15 +3,16 @@
 # This flagfile also serves as the base for the boostrap & eval stages of
 # the RL loop.
 
---num_games=4096
---num_readouts=400
---fastplay_frequency=0.7
---fastplay_readouts=80
+--num_readouts=240
+### --num_readouts=160
+### --fastplay_frequency=0.7
+### --fastplay_readouts=40
 --value_init_penalty=0.2
 --holdout_pct=0.00
 --disable_resign_pct=1.0
 --resign_threshold=-0.99
+--virtual_losses=2
+### --target_pruning=1
 
 # Device-specific selfplay flags.
---parallel_games=2048
---virtual_losses=8
+--cache_size_mb=10240

--- a/ml_perf/flags/9/selfplay.flags
+++ b/ml_perf/flags/9/selfplay.flags
@@ -4,9 +4,8 @@
 # the RL loop.
 
 --num_readouts=240
-### --num_readouts=160
-### --fastplay_frequency=0.7
-### --fastplay_readouts=40
+--fastplay_frequency=0.7
+--fastplay_readouts=40
 --value_init_penalty=0.2
 --holdout_pct=0.00
 --disable_resign_pct=1.0
@@ -15,4 +14,4 @@
 ### --target_pruning=1
 
 # Device-specific selfplay flags.
---cache_size_mb=10240
+### --cache_size_mb=10240

--- a/ml_perf/flags/9/train.flags
+++ b/ml_perf/flags/9/train.flags
@@ -3,7 +3,7 @@
 --flagfile=ml_perf/flags/9/architecture.flags
 
 --shuffle_buffer_size=10000
---filter_amount=0.5
+--filter_amount=1
 
 # Device specific hyperparameters re: batch size and LR schedules.
 --train_batch_size=4096

--- a/ml_perf/reference_implementation.py
+++ b/ml_perf/reference_implementation.py
@@ -31,7 +31,7 @@ import time
 from ml_perf.utils import *
 
 from absl import app, flags
-from rl_loop import example_buffer, fsdb
+from rl_loop import fsdb
 from tensorflow import gfile
 
 N = int(os.environ.get('BOARD_SIZE', 19))
@@ -50,6 +50,11 @@ flags.DEFINE_float('gating_win_rate', 0.55,
                    'Win-rate against the current best required to promote a '
                    'model to new best.')
 
+flags.DEFINE_float('bootstrap_target_win_rate', 0.05,
+                   'Win-rate against the target required to halt '
+                   'bootstrapping and generate the starting training '
+                   'checkpoint')
+
 flags.DEFINE_string('flags_dir', None,
                     'Directory in which to find the flag files for each stage '
                     'of the RL loop. The directory must contain the following '
@@ -63,389 +68,502 @@ flags.DEFINE_boolean('parallel_post_train', False,
                      'If true, run the post-training stages (eval, validation '
                      '& selfplay) in parallel.')
 
+flags.DEFINE_list('train_devices', None, '')
+flags.DEFINE_list('eval_devices', None, '')
+flags.DEFINE_list('selfplay_devices', None, '')
+
+flags.DEFINE_integer('bootstrap_num_models', 8,
+                     'Number of random models to use for bootstrapping.')
+flags.DEFINE_integer('selfplay_num_games', 4096,
+                     'Number of selfplay games to play.')
+flags.DEFINE_integer('selfplay_num_games_per_thread', 3,
+                     'Number of games to play on each thread.')
+flags.DEFINE_integer('eval_num_games', 100,
+                     'Number of selfplay games to play.')
+
 flags.DEFINE_string('engine', 'tf', 'The engine to use for selfplay.')
+
+flags.DEFINE_boolean('bootstrap', False, '')
 
 FLAGS = flags.FLAGS
 
 
 class State:
-  """State data used in each iteration of the RL loop.
+    """State data used in each iteration of the RL loop.
 
-  Models are named with the current reinforcement learning loop iteration number
-  and the model generation (how many models have passed gating). For example, a
-  model named "000015-000007" was trained on the 15th iteration of the loop and
-  is the 7th models that passed gating.
-  Note that we rely on the iteration number being the first part of the model
-  name so that the training chunks sort correctly.
-  """
+    Models are named with the current reinforcement learning loop iteration number
+    and the model generation (how many models have passed gating). For example, a
+    model named "000015-000007" was trained on the 15th iteration of the loop and
+    is the 7th models that passed gating.
+    Note that we rely on the iteration number being the first part of the model
+    name so that the training chunks sort correctly.
+    """
 
-  def __init__(self):
-    self.start_time = time.time()
+    def __init__(self):
+        self.start_time = time.time()
 
-    self.iter_num = 0
-    self.gen_num = 0
+        self.iter_num = 0
+        self.gen_num = 0
 
-    self.best_model_name = None
+        self.best_model_name = None
 
-  @property
-  def output_model_name(self):
-    return '%06d-%06d' % (self.iter_num, self.gen_num)
+    @property
+    def output_model_name(self):
+        return '%06d-%06d' % (self.iter_num, self.gen_num)
 
-  @property
-  def train_model_name(self):
-    return '%06d-%06d' % (self.iter_num, self.gen_num + 1)
+    @property
+    def train_model_name(self):
+        return '%06d-%06d' % (self.iter_num, self.gen_num + 1)
 
-  @property
-  def best_model_path(self):
-    if self.best_model_name is None:
-      # We don't have a good model yet, use a random fake model implementation.
-      return 'random:0,0.4:0.4'
-    else:
-      return '{},{}.pb'.format(
-         FLAGS.engine, os.path.join(fsdb.models_dir(), self.best_model_name))
+    @property
+    def best_model_path(self):
+        return '{}.pb'.format(
+             os.path.join(fsdb.models_dir(), self.best_model_name))
 
-  @property
-  def train_model_path(self):
-    return '{},{}.pb'.format(
-         FLAGS.engine, os.path.join(fsdb.models_dir(), self.train_model_name))
-
-  @property
-  def seed(self):
-    return self.iter_num + 1
+    @property
+    def train_model_path(self):
+        return '{}.pb'.format(
+            os.path.join(fsdb.models_dir(), self.train_model_name))
 
 
 class ColorWinStats:
-  """Win-rate stats for a single model & color."""
+    """Win-rate stats for a single model & color."""
 
-  def __init__(self, total, both_passed, opponent_resigned, move_limit_reached):
-    self.total = total
-    self.both_passed = both_passed
-    self.opponent_resigned = opponent_resigned
-    self.move_limit_reached = move_limit_reached
-    # Verify that the total is correct
-    assert total == both_passed + opponent_resigned + move_limit_reached
+    def __init__(self, total, both_passed, opponent_resigned,
+                 move_limit_reached):
+        self.total = total
+        self.both_passed = both_passed
+        self.opponent_resigned = opponent_resigned
+        self.move_limit_reached = move_limit_reached
+        # Verify that the total is correct
+        assert total == both_passed + opponent_resigned + move_limit_reached
 
 
 class WinStats:
-  """Win-rate stats for a single model."""
+    """Win-rate stats for a single model."""
 
-  def __init__(self, line):
-    pattern = '\s*(\S+)' + '\s+(\d+)' * 8
-    match = re.search(pattern, line)
-    if match is None:
-      raise ValueError('Can\t parse line "{}"'.format(line))
-    self.model_name = match.group(1)
-    raw_stats = [float(x) for x in match.groups()[1:]]
-    self.black_wins = ColorWinStats(*raw_stats[:4])
-    self.white_wins = ColorWinStats(*raw_stats[4:])
-    self.total_wins = self.black_wins.total + self.white_wins.total
+    def __init__(self, line):
+        pattern = '\s*(\S+)' + '\s+(\d+)' * 8
+        match = re.search(pattern, line)
+        if match is None:
+            raise ValueError('Can\t parse line "{}"'.format(line))
+        self.model_name = match.group(1)
+        raw_stats = [float(x) for x in match.groups()[1:]]
+        self.black_wins = ColorWinStats(*raw_stats[:4])
+        self.white_wins = ColorWinStats(*raw_stats[4:])
+        self.total_wins = self.black_wins.total + self.white_wins.total
 
 
 def initialize_from_checkpoint(state):
-  """Initialize the reinforcement learning loop from a checkpoint."""
+    """Initialize the reinforcement learning loop from a checkpoint."""
 
-  # The checkpoint's work_dir should contain the most recently trained model.
-  model_paths = glob.glob(os.path.join(FLAGS.checkpoint_dir,
-                                       'work_dir/model.ckpt-*.pb'))
-  if len(model_paths) != 1:
-    raise RuntimeError('Expected exactly one model in the checkpoint work_dir, '
-                       'got [{}]'.format(', '.join(model_paths)))
-  start_model_path = model_paths[0]
+    # The checkpoint's work_dir should contain the most recently trained model.
+    model_paths = glob.glob(os.path.join(FLAGS.checkpoint_dir,
+                                         'work_dir/model.ckpt-*.pb'))
+    if len(model_paths) != 1:
+        raise RuntimeError('Expected exactly one model in the checkpoint '
+                           'work_dir, got [{}]'.format(', '.join(model_paths)))
+    start_model_path = model_paths[0]
 
-  # Copy the latest trained model into the models directory and use it on the
-  # first round of selfplay.
-  state.best_model_name = 'checkpoint'
-  shutil.copy(start_model_path,
-              os.path.join(fsdb.models_dir(), state.best_model_name + '.pb'))
+    # Copy the latest trained model into the models directory and use it on the
+    # first round of selfplay.
+    state.best_model_name = 'checkpoint'
+    shutil.copy(start_model_path,
+                os.path.join(fsdb.models_dir(), state.best_model_name + '.pb'))
 
-  # Copy the training chunks.
-  golden_chunks_dir = os.path.join(FLAGS.checkpoint_dir, 'golden_chunks')
-  for basename in os.listdir(golden_chunks_dir):
-    path = os.path.join(golden_chunks_dir, basename)
-    shutil.copy(path, fsdb.golden_chunk_dir())
+    # Copy the training chunks.
+    golden_chunks_dir = os.path.join(FLAGS.checkpoint_dir, 'golden_chunks')
+    for basename in os.listdir(golden_chunks_dir):
+        path = os.path.join(golden_chunks_dir, basename)
+        shutil.copy(path, fsdb.golden_chunk_dir())
 
-  # Copy the training files.
-  work_dir = os.path.join(FLAGS.checkpoint_dir, 'work_dir')
-  for basename in os.listdir(work_dir):
-    path = os.path.join(work_dir, basename)
-    shutil.copy(path, fsdb.working_dir())
+    # Copy the training files.
+    work_dir = os.path.join(FLAGS.checkpoint_dir, 'work_dir')
+    for basename in os.listdir(work_dir):
+        path = os.path.join(work_dir, basename)
+        shutil.copy(path, fsdb.working_dir())
 
 
 def parse_win_stats_table(stats_str, num_lines):
-  result = []
-  lines = stats_str.split('\n')
-  while True:
-    # Find the start of the win stats table.
-    assert len(lines) > 1
-    if 'Black' in lines[0] and 'White' in lines[0] and 'm.lmt.' in lines[1]:
-        break
-    lines = lines[1:]
+    result = []
+    lines = stats_str.split('\n')
+    while True:
+        # Find the start of the win stats table.
+        assert len(lines) > 1
+        if 'Black' in lines[0] and 'White' in lines[0] and 'm.lmt.' in lines[1]:
+            break
+        lines = lines[1:]
 
-  # Parse the expected number of lines from the table.
-  for line in lines[2:2 + num_lines]:
-    result.append(WinStats(line))
+    # Parse the expected number of lines from the table.
+    for line in lines[2:2 + num_lines]:
+        result.append(WinStats(line))
 
-  return result
+    return result
 
 
 async def run(*cmd):
-  """Run the given subprocess command in a coroutine.
+    """Run the given subprocess command in a coroutine.
 
-  Args:
-    *cmd: the command to run and its arguments.
+    Args:
+        *cmd: the command to run and its arguments.
 
-  Returns:
-    The output that the command wrote to stdout as a list of strings, one line
-    per element (stderr output is piped to stdout).
+    Returns:
+        The output that the command wrote to stdout as a list of strings, one line
+        per element (stderr output is piped to stdout).
 
-  Raises:
-    RuntimeError: if the command returns a non-zero result.
-  """
+    Raises:
+        RuntimeError: if the command returns a non-zero result.
+    """
 
-  stdout = await checked_run(*cmd)
+    stdout = await checked_run(*cmd)
 
-  log_path = os.path.join(FLAGS.base_dir, get_cmd_name(cmd) + '.log')
-  with gfile.Open(log_path, 'a') as f:
-    f.write(expand_cmd_str(cmd))
-    f.write('\n')
-    f.write(stdout)
-    f.write('\n')
+    log_path = os.path.join(FLAGS.base_dir, get_cmd_name(cmd) + '.log')
+    with gfile.Open(log_path, 'a') as f:
+        f.write(expand_cmd_str(cmd))
+        f.write('\n')
+        f.write(stdout)
+        f.write('\n')
 
-  # Split stdout into lines.
-  return stdout.split('\n')
+    # Split stdout into lines.
+    return stdout.split('\n')
 
 
 def get_golden_chunk_records():
-  """Return up to num_records of golden chunks to train on.
+    """Return up to num_records of golden chunks to train on.
 
-  Returns:
-    A list of golden chunks up to num_records in length, sorted by path.
-  """
+    Returns:
+        A list of golden chunks up to num_records in length, sorted by path.
+    """
 
-  pattern = os.path.join(fsdb.golden_chunk_dir(), '*.zz')
-  return sorted(tf.gfile.Glob(pattern), reverse=True)[:FLAGS.window_size]
+    pattern = os.path.join(fsdb.golden_chunk_dir(), '*.zz')
+    return sorted(tf.gfile.Glob(pattern), reverse=True)[:FLAGS.window_size]
+
+
+async def run_commands(commands):
+    all_tasks = []
+    loop = asyncio.get_event_loop()
+    for cmd in commands:
+        all_tasks.append(loop.create_task(run(*cmd)))
+    all_results = await asyncio.gather(*all_tasks, return_exceptions=True)
+    for cmd, result in zip(commands, all_results):
+        if isinstance(result, Exception):
+            logging.error('error running command:\n  %s',
+                          ' '.join([str(x) for x in cmd]))
+            raise result
+    return all_results
+
+
+async def bootstrap_selfplay(state):
+    output_name = '000000-000000'
+    output_dir = os.path.join(fsdb.selfplay_dir(), output_name)
+    holdout_dir = os.path.join(fsdb.holdout_dir(), output_name)
+    sgf_dir = os.path.join(fsdb.sgf_dir(), output_name)
+
+    selfplay_cmds = []
+    for i in range(FLAGS.bootstrap_num_models):
+        device = i % len(FLAGS.selfplay_devices)
+        architecture_flags = os.path.join(FLAGS.flags_dir,
+                                          'architecture.flags')
+        model_path = os.path.join(
+            fsdb.models_dir(), 'bootstrap-{}'.format(i))
+        await run(
+           'python', 'bootstrap.py',
+           '--flagfile={}'.format(architecture_flags),
+           '--export_path={}'.format(model_path),
+           '--work_dir=/tmp/work_dir')
+        await run(
+            'python', 'freeze_graph.py',
+             '--flagfile={}'.format(architecture_flags),
+             '--model_path={}'.format(model_path))
+
+        selfplay_cmds.append([
+            'bazel-bin/cc/selfplay',
+            '--flagfile={}'.format(os.path.join(FLAGS.flags_dir,
+                                   'bootstrap.flags')),
+            '--num_games={}'.format(FLAGS.selfplay_num_games //
+                                    FLAGS.bootstrap_num_models),
+            '--model={}:{},{}.pb'.format(FLAGS.engine, device, model_path),
+            '--output_dir={}/{}'.format(output_dir, i),
+            '--holdout_dir={}/{}'.format(holdout_dir, i),
+            '--sgf_dir={}'.format(sgf_dir),
+        ])
+
+    all_lines = await run_commands(selfplay_cmds)
+    for lines in all_lines:
+        result = '\n'.join(lines[-6:])
+        logging.info(result)
+
+    src_pattern = os.path.join(output_dir, '*/*', '*.zz')
+    dst_path = os.path.join(fsdb.golden_chunk_dir(),
+                            state.output_model_name + '.tfrecord.zz')
+    logging.info('Writing golden chunk "{}" from "{}"'.format(dst_path,
+                                                              src_pattern))
+    lines = await sample_records(src_pattern, dst_path)
+    logging.info('\n'.join(lines))
+
+
+### async def bootstrap_selfplay(state):
+###     output_name = '000000-000000'
+###     output_dir = os.path.join(fsdb.selfplay_dir(), output_name)
+###     holdout_dir = os.path.join(fsdb.holdout_dir(), output_name)
+###     sgf_dir = os.path.join(fsdb.sgf_dir(), output_name)
+### 
+###     lines = await run(
+###         'bazel-bin/cc/selfplay',
+###         '--flagfile={}'.format(os.path.join(FLAGS.flags_dir,
+###                                'bootstrap.flags')),
+###         '--num_games=8192',
+###         '--parallel_games=32',
+###         '--model=random:0,0.4:0.4',
+###         '--output_dir={}'.format(output_dir),
+###         '--holdout_dir={}'.format(holdout_dir),
+###         '--sgf_dir={}'.format(sgf_dir))
+###     logging.info('\n'.join(lines[-6:]))
+### 
+###     # Write examples to a single record.
+###     src_pattern = os.path.join(output_dir, '*', '*.zz')
+###     dst_path = os.path.join(fsdb.golden_chunk_dir(),
+###                             output_name + '.tfrecord.zz')
+###     logging.info('Writing golden chunk "{}" from "{}"'.format(dst_path,
+###                                                               src_pattern))
+###     lines = await sample_records(src_pattern, dst_path)
+###     logging.info('\n'.join(lines))
 
 
 # Self-play a number of games.
-async def selfplay(state, flagfile='selfplay'):
-  """Run selfplay and write a training chunk to the fsdb golden_chunk_dir.
+async def selfplay(state):
+    """Run selfplay and write a training chunk to the fsdb golden_chunk_dir.
 
-  Args:
-    state: the RL loop State instance.
-    flagfile: the name of the flagfile to use for selfplay, either 'selfplay'
-        (the default) or 'boostrap'.
-  """
+    Args:
+        state: the RL loop State instance.
+    """
 
-  output_dir = os.path.join(fsdb.selfplay_dir(), state.output_model_name)
-  holdout_dir = os.path.join(fsdb.holdout_dir(), state.output_model_name)
+    output_dir = os.path.join(fsdb.selfplay_dir(), state.output_model_name)
+    holdout_dir = os.path.join(fsdb.holdout_dir(), state.output_model_name)
 
-  lines = await run(
-      'bazel-bin/cc/selfplay',
-      '--flagfile={}.flags'.format(os.path.join(FLAGS.flags_dir, flagfile)),
-      '--model={}'.format(state.best_model_path),
-      '--output_dir={}'.format(output_dir),
-      '--holdout_dir={}'.format(holdout_dir),
-      '--seed={}'.format(state.seed))
-  result = '\n'.join(lines[-6:])
-  logging.info(result)
-  stats = parse_win_stats_table(result, 1)[0]
-  num_games = stats.total_wins
-  logging.info('Black won %0.3f, white won %0.3f',
-               stats.black_wins.total / num_games,
-               stats.white_wins.total / num_games)
+    commands = []
+    num_selfplay_processes = len(FLAGS.selfplay_devices)
+    for i, device in enumerate(FLAGS.selfplay_devices):
+        a = ((i - 1) * FLAGS.selfplay_num_games) // (num_selfplay_processes - 1)
+        b = (i * FLAGS.selfplay_num_games) // (num_selfplay_processes - 1)
+        num_games = b - a
+        parallel_games = (
+            (num_games + FLAGS.selfplay_num_games_per_thread - 1) //
+            FLAGS.selfplay_num_games_per_thread)
 
-  # Write examples to a single record.
-  pattern = os.path.join(output_dir, '*', '*.zz')
-  random.seed(state.seed)
-  tf.set_random_seed(state.seed)
-  np.random.seed(state.seed)
-  # TODO(tommadams): This method of generating one golden chunk per generation
-  # is sub-optimal because each chunk gets reused multiple times for training,
-  # introducing bias. Instead, a fresh dataset should be uniformly sampled out
-  # of *all* games in the training window before the start of each training run.
-  buffer = example_buffer.ExampleBuffer(sampling_frac=1.0)
+        commands.append([
+            'bazel-bin/cc/selfplay',
+            '--flagfile={}'.format(os.path.join(FLAGS.flags_dir,
+                                   'selfplay.flags')),
+            '--num_games={}'.format(num_games),
+            '--parallel_games={}'.format(parallel_games),
+            '--model={}:{},{}'.format(FLAGS.engine, device,
+                                      state.best_model_path),
+            '--output_dir={}/{}'.format(output_dir, i),
+            '--holdout_dir={}/{}'.format(holdout_dir, i)])
 
-  # TODO(tommadams): parallel_fill is currently non-deterministic. Make it not
-  # so.
-  logging.info('Writing golden chunk from "{}"'.format(pattern))
-  buffer.parallel_fill(tf.gfile.Glob(pattern))
-  buffer.flush(os.path.join(fsdb.golden_chunk_dir(),
-                            state.output_model_name + '.tfrecord.zz'))
+    all_lines = await run_commands(commands)
+
+    black_wins_total = white_wins_total = num_games = 0
+    for lines in all_lines:
+        result = '\n'.join(lines[-6:])
+        logging.info(result)
+        stats = parse_win_stats_table(result, 1)[0]
+        num_games += stats.total_wins
+        black_wins_total += stats.black_wins.total
+        white_wins_total += stats.white_wins.total
+
+    logging.info('Black won %0.3f, white won %0.3f',
+                 black_wins_total / num_games,
+                 white_wins_total / num_games)
+
+    # Write examples to a single record.
+    src_pattern = os.path.join(output_dir, '*/*', '*.zz')
+    dst_path = os.path.join(fsdb.golden_chunk_dir(),
+                            state.output_model_name + '.tfrecord.zz')
+    logging.info('Writing golden chunk "{}" from "{}"'.format(dst_path,
+                                                              src_pattern))
+    lines = await sample_records(src_pattern, dst_path)
+    logging.info('\n'.join(lines))
 
 
 async def train(state, tf_records):
-  """Run training and write a new model to the fsdb models_dir.
+    """Run training and write a new model to the fsdb models_dir.
 
-  Args:
-    state: the RL loop State instance.
-    tf_records: a list of paths to TensorFlow records to train on.
-  """
+    Args:
+        state: the RL loop State instance.
+        tf_records: a list of paths to TensorFlow records to train on.
+    """
 
-  model_path = os.path.join(fsdb.models_dir(), state.train_model_name)
-  await run(
-      'python3', 'train.py', *tf_records,
-      '--flagfile={}'.format(os.path.join(FLAGS.flags_dir, 'train.flags')),
-      '--work_dir={}'.format(fsdb.working_dir()),
-      '--export_path={}'.format(model_path),
-      '--training_seed={}'.format(state.seed),
-      '--freeze=true')
-  # Append the time elapsed from when the RL was started to when this model
-  # was trained.
-  elapsed = time.time() - state.start_time
-  timestamps_path = os.path.join(fsdb.models_dir(), 'train_times.txt')
-  with gfile.Open(timestamps_path, 'a') as f:
-    print('{:.3f} {}'.format(elapsed, state.train_model_name), file=f)
-
-
-async def validate(state, holdout_glob):
-  """Validate the trained model against holdout games.
-
-  Args:
-    state: the RL loop State instance.
-    holdout_glob: a glob that matches holdout games.
-  """
-
-  if not glob.glob(holdout_glob):
-    print('Glob "{}" didn\'t match any files, skipping validation'.format(
-          holdout_glob))
-  else:
+    model_path = os.path.join(fsdb.models_dir(), state.train_model_name)
     await run(
-        'python3', 'validate.py', holdout_glob,
-        '--flagfile={}'.format(os.path.join(FLAGS.flags_dir, 'validate.flags')),
-        '--work_dir={}'.format(fsdb.working_dir()))
+        'python3', 'train.py',
+        '--gpu_device_list={}'.format(','.join(FLAGS.train_devices)),
+        '--flagfile={}'.format(os.path.join(FLAGS.flags_dir, 'train.flags')),
+        '--work_dir={}'.format(fsdb.working_dir()),
+        '--export_path={}'.format(model_path),
+        '--freeze=true',
+        *tf_records)
+
+    # Append the time elapsed from when the RL was started to when this model
+    # was trained.
+    elapsed = time.time() - state.start_time
+    timestamps_path = os.path.join(fsdb.models_dir(), 'train_times.txt')
+    with gfile.Open(timestamps_path, 'a') as f:
+        print('{:.3f} {}'.format(elapsed, state.train_model_name), file=f)
 
 
-async def evaluate_model(eval_model_path, target_model_path, sgf_dir, seed):
-  """Evaluate one model against a target.
+async def train_eval(state, tf_records):
+    await train(state, tf_records)
+    return await evaluate_trained_model(state)
 
-  Args:
-    eval_model_path: the path to the model to evaluate.
-    target_model_path: the path to the model to compare to.
-    sgf_dif: directory path to write SGF output to.
-    seed: random seed to use when running eval.
 
-  Returns:
-    The win-rate of eval_model against target_model in the range [0, 1].
-  """
+async def evaluate_model(eval_model_path, target_model_path, sgf_dir):
+    """Evaluate one model against a target.
 
-  lines = await run(
-      'bazel-bin/cc/eval',
-      '--flagfile={}'.format(os.path.join(FLAGS.flags_dir, 'eval.flags')),
-      '--model={}'.format(eval_model_path),
-      '--model_two={}'.format(target_model_path),
-      '--sgf_dir={}'.format(sgf_dir),
-      '--seed={}'.format(seed))
-  result = '\n'.join(lines[-7:])
-  logging.info(result)
-  eval_stats, target_stats = parse_win_stats_table(result, 2)
-  num_games = eval_stats.total_wins + target_stats.total_wins
-  win_rate = eval_stats.total_wins / num_games
-  logging.info('Win rate %s vs %s: %.3f', eval_stats.model_name,
-               target_stats.model_name, win_rate)
-  return win_rate
+    Args:
+        eval_model_path: the path to the model to evaluate.
+        target_model_path: the path to the model to compare to.
+        sgf_dif: directory path to write SGF output to.
+
+    Returns:
+        The win-rate of eval_model against target_model in the range [0, 1].
+    """
+
+    lines = await run(
+        'bazel-bin/cc/eval',
+        '--flagfile={}'.format(os.path.join(FLAGS.flags_dir, 'eval.flags')),
+        '--model={}:{},{}'.format(FLAGS.engine, FLAGS.eval_devices[0],
+                                  eval_model_path),
+        '--model_two={}:{},{}'.format(FLAGS.engine, FLAGS.eval_devices[0],
+                                      target_model_path),
+        '--parallel_games={}'.format(FLAGS.eval_num_games),
+        '--sgf_dir={}'.format(sgf_dir))
+    result = '\n'.join(lines[-7:])
+    logging.info(result)
+    eval_stats, target_stats = parse_win_stats_table(result, 2)
+    num_games = eval_stats.total_wins + target_stats.total_wins
+    win_rate = eval_stats.total_wins / num_games
+    logging.info('Win rate %s vs %s: %.3f', eval_stats.model_name,
+                 target_stats.model_name, win_rate)
+    return win_rate
 
 
 async def evaluate_trained_model(state):
-  """Evaluate the most recently trained model against the current best model.
+    """Evaluate the most recently trained model against the current best model.
 
-  Args:
-    state: the RL loop State instance.
-  """
+    Args:
+        state: the RL loop State instance.
+    """
 
-  return await evaluate_model(
-      state.train_model_path, state.best_model_path,
-      os.path.join(fsdb.eval_dir(), state.train_model_name), state.seed)
+    return await evaluate_model(
+        state.train_model_path, state.best_model_path,
+        os.path.join(fsdb.eval_dir(), state.train_model_name))
+
+
+async def sample_records(src_pattern, dst_path):
+    # TODO(tommadams): expose flags
+    return await run(
+        'bazel-bin/cc/sample_records',
+        '--num_read_threads=1',
+        '--sample_frac=1',
+        '--compression=1',
+        '--shuffle=true',
+        '--dst={}'.format(dst_path),
+        src_pattern)
 
 
 def rl_loop():
-  """The main reinforcement learning (RL) loop."""
+    """The main reinforcement learning (RL) loop."""
 
-  state = State()
+    state = State()
 
-  if FLAGS.checkpoint_dir:
-    # Start from a partially trained model.
-    initialize_from_checkpoint(state)
-  else:
-    # Play the first round of selfplay games with a fake model that returns
-    # random noise. We do this instead of playing multiple games using a single
-    # model bootstrapped with random noise to avoid any initial bias.
-    wait(selfplay(state, 'bootstrap'))
+    if FLAGS.bootstrap:
+        # Play the first round of selfplay games with a fake model that returns
+        # random noise. We do this instead of playing multiple games using a
+        # single model bootstrapped with random noise to avoid any initial bias.
+        wait(bootstrap_selfplay(state))
 
-    # Train a real model from the random selfplay games.
-    tf_records = get_golden_chunk_records()
-    state.iter_num += 1
-    wait(train(state, tf_records))
+        # Train a real model from the random selfplay games.
+        tf_records = get_golden_chunk_records()
+        state.iter_num += 1
+        wait(train(state, tf_records))
 
-    # Select the newly trained model as the best.
-    state.best_model_name = state.train_model_name
-    state.gen_num += 1
+        # Select the newly trained model as the best.
+        state.best_model_name = state.train_model_name
+        state.gen_num += 1
 
-    # Run selfplay using the new model.
-    wait(selfplay(state))
-
-  # Now start the full training loop.
-  while state.iter_num <= FLAGS.iterations:
-    # Build holdout glob before incrementing the iteration number because we
-    # want to run validation on the previous generation.
-    holdout_glob = os.path.join(fsdb.holdout_dir(), '%06d-*' % state.iter_num,
-                                '*')
-
-    # Train on shuffled game data from recent selfplay rounds.
-    tf_records = get_golden_chunk_records()
-    state.iter_num += 1
-    wait(train(state, tf_records))
-
-    if FLAGS.parallel_post_train:
-      # Run eval, validation & selfplay in parallel.
-      model_win_rate, _, _ = wait([
-          evaluate_trained_model(state),
-          validate(state, holdout_glob),
-          selfplay(state)])
+        # Run selfplay using the new model.
+        wait(selfplay(state))
     else:
-      # Run eval, validation & selfplay sequentially.
-      model_win_rate = wait(evaluate_trained_model(state))
-      wait(validate(state, holdout_glob))
-      wait(selfplay(state))
+        # Start from a partially trained model.
+        initialize_from_checkpoint(state)
 
-    if model_win_rate >= FLAGS.gating_win_rate:
-      # Promote the trained model to the best model and increment the generation
-      # number.
-      state.best_model_name = state.train_model_name
-      state.gen_num += 1
+    prev_win_rate_vs_target = 0
+
+    # Now start the full training loop.
+    while state.iter_num <= FLAGS.iterations:
+        tf_records = get_golden_chunk_records()
+        state.iter_num += 1
+
+        # Run selfplay in parallel with sequential (train, eval).
+        model_win_rate, _ = wait([
+            train_eval(state, tf_records),
+            selfplay(state)])
+
+        # If we're bootstrapping a checkpoint, evaluate the newly trained model
+        # against the target.
+        if FLAGS.bootstrap:
+            target_model_path = os.path.join(fsdb.models_dir(), 'target.pb')
+            sgf_dir = os.path.join(
+                fsdb.eval_dir(),
+                '{}-vs-target'.format(state.train_model_name))
+            win_rate_vs_target = wait(evaluate_model(
+                state.train_model_path, target_model_path, sgf_dir))
+            if (win_rate_vs_target >= FLAGS.bootstrap_target_win_rate and
+                prev_win_rate_vs_target > 0):
+                break
+            prev_win_rate_vs_target = win_rate_vs_target
+
+        if model_win_rate >= FLAGS.gating_win_rate:
+            # Promote the trained model to the best model and increment the
+            # generation number.
+            state.best_model_name = state.train_model_name
+            state.gen_num += 1
 
 
 def main(unused_argv):
-  """Run the reinforcement learning loop."""
+    """Run the reinforcement learning loop."""
 
-  print('Wiping dir %s' % FLAGS.base_dir, flush=True)
-  shutil.rmtree(FLAGS.base_dir, ignore_errors=True)
-  dirs = [fsdb.models_dir(), fsdb.selfplay_dir(), fsdb.holdout_dir(),
-          fsdb.eval_dir(), fsdb.golden_chunk_dir(), fsdb.working_dir()]
-  for d in dirs:
-    ensure_dir_exists(d);
+    print('Wiping dir %s' % FLAGS.base_dir, flush=True)
+    shutil.rmtree(FLAGS.base_dir, ignore_errors=True)
+    dirs = [fsdb.models_dir(), fsdb.selfplay_dir(), fsdb.holdout_dir(),
+            fsdb.eval_dir(), fsdb.golden_chunk_dir(), fsdb.working_dir()]
+    for d in dirs:
+        ensure_dir_exists(d);
 
-  # Copy the flag files so there's no chance of them getting accidentally
-  # overwritten while the RL loop is running.
-  flags_dir = os.path.join(FLAGS.base_dir, 'flags')
-  shutil.copytree(FLAGS.flags_dir, flags_dir)
-  FLAGS.flags_dir = flags_dir
+    # Copy the flag files so there's no chance of them getting accidentally
+    # overwritten while the RL loop is running.
+    flags_dir = os.path.join(FLAGS.base_dir, 'flags')
+    shutil.copytree(FLAGS.flags_dir, flags_dir)
+    FLAGS.flags_dir = flags_dir
 
-  # Copy the target model to the models directory so we can find it easily.
-  shutil.copy(FLAGS.target_path, os.path.join(fsdb.models_dir(), 'target.pb'))
+    # Copy the target model to the models directory so we can find it easily.
+    shutil.copy(FLAGS.target_path, os.path.join(fsdb.models_dir(), 'target.pb'))
 
-  logging.getLogger().addHandler(
-      logging.FileHandler(os.path.join(FLAGS.base_dir, 'rl_loop.log')))
-  formatter = logging.Formatter('[%(asctime)s] %(message)s',
-                                '%Y-%m-%d %H:%M:%S')
-  for handler in logging.getLogger().handlers:
-    handler.setFormatter(formatter)
+    logging.getLogger().addHandler(
+          logging.FileHandler(os.path.join(FLAGS.base_dir, 'rl_loop.log')))
+    formatter = logging.Formatter('[%(asctime)s] %(message)s',
+                                  '%Y-%m-%d %H:%M:%S')
+    for handler in logging.getLogger().handlers:
+        handler.setFormatter(formatter)
 
-  with logged_timer('Total time'):
-    try:
-      rl_loop()
-    finally:
-      asyncio.get_event_loop().close()
+    with logged_timer('Total time'):
+        try:
+            rl_loop()
+        finally:
+            asyncio.get_event_loop().close()
 
 
 if __name__ == '__main__':
-  app.run(main)
+    app.run(main)

--- a/ml_perf/utils.py
+++ b/ml_perf/utils.py
@@ -26,78 +26,79 @@ from utils import *
 
 
 def expand_cmd_str(cmd):
-  return '  '.join(flags.FlagValues().read_flags_from_files(cmd))
+    return '  '.join(flags.FlagValues().read_flags_from_files(cmd))
 
 
 def get_cmd_name(cmd):
-  if cmd[0] == 'python' or cmd[0] == 'python3':
-    path = cmd[1]
-  else:
-    path = cmd[0]
-  return os.path.splitext(os.path.basename(path))[0]
+    if cmd[0] == 'python' or cmd[0] == 'python3':
+        path = cmd[1]
+    else:
+        path = cmd[0]
+    return os.path.splitext(os.path.basename(path))[0]
 
 
 async def checked_run(*cmd):
-  """Run the given subprocess command in a coroutine.
+    """Run the given subprocess command in a coroutine.
 
-  Args:
-    *cmd: the command to run and its arguments.
+    Args:
+        *cmd: the command to run and its arguments.
 
-  Returns:
-    The output that the command wrote to stdout.
+    Returns:
+        The output that the command wrote to stdout.
 
-  Raises:
-    RuntimeError: if the command returns a non-zero result.
-  """
+    Raises:
+        RuntimeError: if the command returns a non-zero result.
+    """
 
-  # Start the subprocess.
-  logging.info('Running: %s', expand_cmd_str(cmd))
-  with logged_timer('{} finished'.format(get_cmd_name(cmd))):
-    p = await asyncio.create_subprocess_exec(
-        *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT)
+    # Start the subprocess.
+    logging.info('Running: %s', expand_cmd_str(cmd))
+    with logged_timer('{} finished'.format(get_cmd_name(cmd))):
+        p = await asyncio.create_subprocess_exec(
+            *cmd, stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT)
 
-    # Stream output from the process stdout.
-    chunks = []
-    while True:
-      chunk = await p.stdout.read(16 * 1024)
-      if not chunk:
-        break
-      chunks.append(chunk)
+        # Stream output from the process stdout.
+        chunks = []
+        while True:
+            chunk = await p.stdout.read(16 * 1024)
+            if not chunk:
+                break
+            chunks.append(chunk)
 
-    # Wait for the process to finish, check it was successful & build stdout.
-    await p.wait()
-    stdout = b''.join(chunks).decode()[:-1]
-    if p.returncode:
-      raise RuntimeError('Return code {} from process: {}\n{}'.format(
-          p.returncode, expand_cmd_str(cmd), stdout))
+        # Wait for the process to finish, check it was successful & build stdout.
+        await p.wait()
+        stdout = b''.join(chunks).decode()[:-1]
+        if p.returncode:
+            raise RuntimeError('Return code {} from process: {}\n{}'.format(
+                p.returncode, expand_cmd_str(cmd), stdout))
 
-    return stdout
+        return stdout
 
 
 def wait(aws):
-  """Waits for all of the awaitable objects (e.g. coroutines) in aws to finish.
+    """Waits for all of the awaitable objects (e.g. coroutines) in aws to finish.
 
-  All the awaitable objects are waited for, even if one of them raises an
-  exception. When one or more awaitable raises an exception, the exception from
-  the awaitable with the lowest index in the aws list will be reraised.
+    All the awaitable objects are waited for, even if one of them raises an
+    exception. When one or more awaitable raises an exception, the exception
+    from the awaitable with the lowest index in the aws list will be reraised.
 
-  Args:
-    aws: a single awaitable, or list awaitables.
+    Args:
+        aws: a single awaitable, or list awaitables.
 
-  Returns:
-    If aws is a single awaitable, its result.
-    If aws is a list of awaitables, a list containing the of each awaitable in
-    the list.
+    Returns:
+        If aws is a single awaitable, its result.
+        If aws is a list of awaitables, a list containing the of each awaitable
+        in the list.
 
-  Raises:
-    Exception: if any of the awaitables raises.
-  """
+    Raises:
+        Exception: if any of the awaitables raises.
+    """
 
-  aws_list = aws if isinstance(aws, list) else [aws]
-  results = asyncio.get_event_loop().run_until_complete(asyncio.gather(
-      *aws_list, return_exceptions=True))
-  # If any of the cmds failed, re-raise the error.
-  for result in results:
-    if isinstance(result, Exception):
-      raise result
-  return results if isinstance(aws, list) else results[0]
+    aws_list = aws if isinstance(aws, list) else [aws]
+    results = asyncio.get_event_loop().run_until_complete(asyncio.gather(
+        *aws_list, return_exceptions=True))
+    # If any of the cmds failed, re-raise the error.
+    for result in results:
+        if isinstance(result, Exception):
+            raise result
+    return results if isinstance(aws, list) else results[0]


### PR DESCRIPTION
This is still something of a work in progress but it is able to bootstrap & train a model to the checkpoint cutoff criteria (beat the target in 5/100 games).

Main changes:
 - TfDualNet can now be run on specific GPUs.
 - With the current flags, MLPerf RL loop runs train & eval serially on GPU 0, in parallel with selfplay on GPUs 1-7.
 - With `--bootstrap=true`, eval is performed against the target model during each iteration of the loop, and training stops once the trained model beats the target 5/100 times.
- RandomDualNet will now perform "inference" on all CPU cores instead of just one.

Still to do:
 - Generate a checkpoint directory at the end of bootstrapping.
 - Actually test training a model until it beats the target 50% of the time.