### PR TITLE
Enhancement debian package manager tweaks

### DIFF
--- a/cc/README.md
+++ b/cc/README.md
@@ -21,14 +21,14 @@ sudo ldconfig
 Now, you're ready to compile TensorFlow from source:
 
 ```shell
-sudo apt-get install zip
+sudo apt-get --no-install-recommends  install -y apt-utils ca-certificates zip
 ./cc/configure_tensorflow.sh
 ```
 
 If you want to compile for CPU and not GPU, then execute the following instead:
 
 ```shell
-sudo apt-get install zip
+sudo apt-get --no-install-recommends  install -y apt-utils ca-certificates zip
 TF_NEED_CUDA=0 ./cc/configure_tensorflow.sh
 ```
 

--- a/cluster/base/Dockerfile
+++ b/cluster/base/Dockerfile
@@ -5,7 +5,7 @@ FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu16.04
 ENV LC_ALL="C.UTF-8"
 ENV LC_CTYPE="C.UTF-8"
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates\
         build-essential \
         cuda-command-line-tools-10-0 \
         cuda-cublas-dev-10-0 \
@@ -41,7 +41,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
     echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    apt-get update -y && apt-get install google-cloud-sdk -y
+    apt-get update -y && apt-get --no-install-recommends  install -y apt-utils ca-certificates google-cloud-sdk -y
 
 ENV BAZEL_VERSION 0.24.1
 

--- a/cluster/cgos/Dockerfile
+++ b/cluster/cgos/Dockerfile
@@ -1,6 +1,6 @@
 FROM gcr.io/${PROJECT}/cc-base:v14
 
-RUN apt-get update && apt-get install gettext -y
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates gettext -y
 
 COPY cgosGtp-linux-x86_64 /app
 

--- a/cluster/evaluator/Dockerfile-cc
+++ b/cluster/evaluator/Dockerfile-cc
@@ -5,9 +5,9 @@ from base-build-manual2
 RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
     echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    apt-get update -y && apt-get install google-cloud-sdk -y
+    apt-get update -y && apt-get --no-install-recommends  install -y apt-utils ca-certificates google-cloud-sdk -y
 
-RUN apt-get install python3 python3-pip -y
+RUN apt-get --no-install-recommends  install -y apt-utils ca-certificates python3 python3-pip -y
 RUN pip3 install absl-py
 
 COPY staging/ /app

--- a/cluster/evaluator/Dockerfile-py
+++ b/cluster/evaluator/Dockerfile-py
@@ -1,6 +1,6 @@
 FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu16.04
 
-RUN apt update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates\
         build-essential \
         bc \
         cuda-command-line-tools-10-0 \

--- a/cluster/evaluator/Dockerfile-ringmaster
+++ b/cluster/evaluator/Dockerfile-ringmaster
@@ -4,9 +4,9 @@ from base-build-manual2
 RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
     echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    apt-get update -y && apt-get install google-cloud-sdk -y
+    apt-get update -y && apt-get --no-install-recommends  install -y apt-utils ca-certificates google-cloud-sdk -y
 
-RUN apt-get install python3 python3-pip -y
+RUN apt-get --no-install-recommends  install -y apt-utils ca-certificates python3 python3-pip -y
 # TODO(AMJ): Get this to compile, determine base & pip requirementes
 RUN pip3 install absl-py
 

--- a/cluster/minigui/Dockerfile
+++ b/cluster/minigui/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:2.7-slim
 
-RUN apt update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates\
         build-essential \
         curl \
         git \
@@ -29,7 +29,7 @@ ENV PATH /google-cloud-sdk/bin:$PATH
 RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
     echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    apt-get update -y && apt-get install google-cloud-sdk -y
+    apt-get update -y && apt-get --no-install-recommends  install -y apt-utils ca-certificates google-cloud-sdk -y
 VOLUME ["/root/.config"]
 
 WORKDIR /app

--- a/cluster/ringmaster/lz-Dockerfile
+++ b/cluster/ringmaster/lz-Dockerfile
@@ -1,11 +1,11 @@
 FROM nvidia/opencl:runtime-ubuntu16.04
 RUN apt-get update --no-upgrade -yq && \
-    apt-get install --no-upgrade -yq curl git clinfo cmake g++ libboost-dev libboost-program-options-dev libboost-filesystem-dev opencl-headers ocl-icd-libopencl1 ocl-icd-opencl-dev zlib1g-dev qtbase5-dev python-virtualenv lsb-release
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates --no-upgrade -yq curl git clinfo cmake g++ libboost-dev libboost-program-options-dev libboost-filesystem-dev opencl-headers ocl-icd-libopencl1 ocl-icd-opencl-dev zlib1g-dev qtbase5-dev python-virtualenv lsb-release
 
 RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
     echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    apt-get update -y && apt-get install google-cloud-sdk -y
+    apt-get update -y && apt-get --no-install-recommends  install -y apt-utils ca-certificates google-cloud-sdk -y
 
 
 # Install Leela.

--- a/cluster/selfplay/Dockerfile-py
+++ b/cluster/selfplay/Dockerfile-py
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates\
         build-essential \
         curl \
         git \

--- a/minigui/edgetpu/install_requirements.sh
+++ b/minigui/edgetpu/install_requirements.sh
@@ -17,10 +17,10 @@ python3 -m pip install -r minigui/requirements.txt
 
 # For Raspberry Pi
 if grep -q "Raspberry Pi" /sys/firmware/devicetree/base/model; then
-  sudo apt-get install chromium xautomation
+  sudo apt-get --no-install-recommends  install -y apt-utils ca-certificates chromium xautomation
 # For DevBoard
 elif grep -q "MX8MQ" /sys/firmware/devicetree/base/model; then
-  sudo apt-get install chromium xautomation
+  sudo apt-get --no-install-recommends  install -y apt-utils ca-certificates chromium xautomation
 else
   echo "Generic Linux system"
 fi

--- a/ml_perf/README.md
+++ b/ml_perf/README.md
@@ -15,7 +15,7 @@ cards.
 
 ```
     # Install dependencies
-    apt-get install -y python3 python3-pip rsync git wget pkg-config zip g++ zlib1g-dev unzip
+    apt-get --no-install-recommends  install -y apt-utils ca-certificatespython3 python3-pip rsync git wget pkg-config zip g++ zlib1g-dev unzip
 
     # Clone repository.
     git clone https://github.com/tensorflow/minigo

--- a/testing/Dockerfile.v2
+++ b/testing/Dockerfile.v2
@@ -22,7 +22,7 @@ FROM gcr.io/$PROJECT/cc-base:latest
 ARG IMAGE_ARG
 ENV IMAGE=${IMAGE_ARG}
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates\
     rsync \
     git \
     clang-format \


### PR DESCRIPTION
Major Changes No 1 : debian package manager tweaks

By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Major Changes No 2 : added packages apt-utils ca-certificates

Because build is

1.  Slow because "apt-utils" not installed

2. to avoid build to exits with error without having certificate in wget , curl or even git clone

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>