### PR TITLE
Add channel order param to preprocessing tests.

### DIFF
--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -59,14 +59,14 @@ class TestPreprocessing(test_utils.MinigoUnitTest):
 
     def extract_data(self, tf_record, filter_amount=1, random_rotation=False):
         pos_tensor, label_tensors = preprocessing.get_input_tensors(
-            1, [tf_record], num_repeats=1, shuffle_records=False,
+            1, 'nhwc', [tf_record], num_repeats=1, shuffle_records=False,
             shuffle_examples=False, filter_amount=filter_amount,
             random_rotation=random_rotation)
         return self.get_data_tensors(pos_tensor, label_tensors)
 
     def extract_tpu_data(self, tf_record, random_rotation=False):
         dataset = preprocessing.get_tpu_input_tensors(
-            1, [tf_record], num_repeats=1, shuffle_records=False,
+            1, 'nhwc', [tf_record], num_repeats=1, shuffle_records=False,
             shuffle_examples=False, filter_amount=1,
             random_rotation=random_rotation)
         pos_tensor, label_tensors = dataset.make_one_shot_iterator().get_next()


### PR DESCRIPTION
These tests were not passing due to a change introduced in 2dd2efb which
added a parameter to the function get_input_tensors, but did not update
the tests.

Note that there is still a single failing test that I have not
investigated:

```
======================================================================
FAIL: test_rotate_pyfunc (tests.test_preprocessing.TestPreprocessing)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./tests/test_preprocessing.py", line 194, in test_rotate_pyfunc
    self.assert_rotate_data(run_one, run_two, run_three)
  File "./tests/test_preprocessing.py", line 128, in assert_rotate_data
    self.assertEqual(set(), difference, "Didn't find these rotations")
AssertionError: Items in the second set but not the first:
'flip' : Didn't find these rotations
```