### PR TITLE
Fixed MiniGUI-related crashes

### DIFF
--- a/cc/minigui_gtp_client.cc
+++ b/cc/minigui_gtp_client.cc
@@ -279,7 +279,7 @@ GtpClient::Response MiniguiGtpClient::ReplaySgf(
 
 void MiniguiGtpClient::ReportSearchStatus(const MctsNode* leaf,
                                           bool include_tree_stats) {
-  auto sorted_child_info = player_->tree().CalculateRankedChildInfo();
+  auto sorted_child_info = player_->tree().CalculateRankedMoveInfo();
   auto* root = player_->root();
 
   nlohmann::json j = {

--- a/minigui/fetch-and-run.sh
+++ b/minigui/fetch-and-run.sh
@@ -40,7 +40,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
   echo "MINIGUI_BOARD_SIZE:  ${MINIGUI_BOARD_SIZE}"
   echo "MINIGUI_PORT:        ${MINIGUI_PORT}"
   echo "MINIGUI_HOST:        ${MINIGUI_HOST}"
-  echo "MINIGUI_CONV_WIDTH:  ${MINIGUI_CONV_WIDTH}"
   echo "MINIGUI_NUM_READS:   ${MINIGUI_NUM_READS}"
 
   pyversion=$($MINIGUI_PYTHON --version)
@@ -74,7 +73,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
     echo "--------------------------------------------------"
 
     BOARD_SIZE=$MINIGUI_BOARD_SIZE $MINIGUI_PYTHON freeze_graph.py \
-        --model_path=${model_path} --conv_width=$MINIGUI_CONV_WIDTH
+        --model_path=${model_path}
   fi
 
   echo
@@ -93,7 +92,6 @@ players = {
                        " --load_file=${model_path}"
                        " --minigui_mode=true"
                        " --num_readouts=${MINIGUI_NUM_READS}"
-                       " --conv_width=${MINIGUI_CONV_WIDTH}"
                        " --resign_threshold=-0.8"
                        " --verbose=2",
                        startup_gtp_commands=[],


### PR DESCRIPTION
On a fresh setup, I was trying to get MiniGUI running, and came across two minor crashes that seem to be caused by legacy code that lagged behind changes made elsewhere in the repository. This PR fixes both of those crashes.

One of the issues is this one: https://github.com/tensorflow/minigo/issues/982
