### PR TITLE
Pinning flask-socketio version

### DIFF
--- a/minigui/requirements.txt
+++ b/minigui/requirements.txt
@@ -1,4 +1,4 @@
 absl-py
 numpy
 flask
-flask-socketio
+flask-socketio==4.3.2


### PR DESCRIPTION
Currently, compatibility issues between the socket-io client and server will prevent minigui from communicating. Recommend pinning the version here to ensure compatibility.